### PR TITLE
ci(hygiene): §7 tree check, workspace metadata, pre-publish noise (closes #13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,19 @@ jobs:
         shell: bash
         run: just ci
 
+  privacy:
+    name: privacy tree check (§7)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No private/ paths tracked
+        run: |
+          leaked=$(git ls-files private/)
+          if [ -n "$leaked" ]; then
+            printf 'ERROR: private/ paths are committed (AGENTS.md §7 violation):\n%s\n' "$leaked" >&2
+            exit 1
+          fi
+
   docs-links:
     name: docs link check
     runs-on: ubuntu-latest

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,8 +1,16 @@
 name: release-plz
 
+# Disabled until M3 (first crates.io publish).
+# Before re-enabling:
+#   1. Enable repo setting: Settings → Actions → General → Workflow permissions
+#      → "Allow GitHub Actions to create and approve pull requests".
+#      Otherwise the action hits HTTP 403 on every main push.
+#   2. Add CARGO_REGISTRY_TOKEN to repository secrets.
+#   3. Restore the `push: branches: [main]` trigger below.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
 
 permissions:
   contents: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.0.0"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
-repository = "https://github.com/dynovant/physa-db"
+repository = "https://github.com/mroche14/physa-db"
 authors = ["physa-db contributors"]
 
 [workspace.lints.rust]


### PR DESCRIPTION
## Summary

Three small hygiene fixes surfaced by the post-#1 audit.

- **Privacy tree check.** New CI job fails when `git ls-files private/` returns anything — mechanical §7 enforcement without a toolchain, sub-second feedback.
- **Workspace metadata.** `Cargo.toml` repository URL now points at the real repo (`mroche14/physa-db`, not `dynovant/physa-db`). Fixes crates.io links for the first publish.
- **release-plz noise.** Trigger reduced to `workflow_dispatch`. It was HTTP 403-failing on every main push (repo setting "Allow GH Actions to create PRs" is off, and we're pre-publish anyway). The in-file comment is the re-enable checklist for M3.

Orphan branches (`release-plz-2026-04-20T12-28-56Z` and 3 others) deleted from origin.

## Test plan

- [x] `git ls-files private/` returns empty locally
- [ ] CI `privacy` job is green on this PR
- [ ] `release-plz` does not trigger on this push (only `workflow_dispatch`)

Closes #13