### PR TITLE
docs(agents): codify credential-safety rule in §10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,11 @@ Do not silently drop work. Do not force a workaround that compromises §0.
 - Adding a top-level dependency with a restrictive licence (GPL, AGPL, SSPL, BSL, commercial).
 - Any git operation with `--no-verify`.
 - **Committing anything from `private/` or referencing competitors by name in public files.**
+- **Committing, pushing, or otherwise persisting any credential, API key, token, password, or secret of any kind.** This includes:
+  - Scanning staged diffs for env-like patterns (`*_KEY=`, `*_TOKEN=`, `*_SECRET=`, `Bearer `, UUID-format API keys) before every commit.
+  - Never running commands that would print a cred to the terminal (`echo $SECRET`, `curl -v` with auth headers, `cat .env`, partial-prefix displays via `head -c`). To verify a cred exists, use existence checks only: `[ -n "$KEY" ] && echo OK`.
+  - If a cred is accidentally printed in the transcript, flag it to the human immediately — don't hide it.
+  - Pre-commit hooks (§13) MUST include a secret-scan gate; treat its failure as a hard stop, never `--no-verify`.
 - Introducing a "shortcut" — a deliberately-suboptimal approach chosen because the better one is harder. See §12.
 
 When in doubt, **ask**.


### PR DESCRIPTION
Never commit, push, echo, or otherwise persist any credential, API key, token, password, or secret. Use boolean existence checks (`[ -n "$KEY" ]`) to verify creds are set — never partial-prefix displays via `head -c`, `echo ${KEY:0:N}`, `curl -v` with auth headers, or `cat .env`. Pre-commit hooks (§13) must include a secret-scan gate; never bypass with `--no-verify`.

## What
<!-- One paragraph describing the change. -->

## Why
<!-- Link the related issue with `Closes #N`. Summarise motivation. -->
Closes #

## How
<!-- Key design choices. Trade-offs. Alternatives rejected. -->

## Benchmarks
<!-- Required for type:perf PRs. Omit otherwise. -->
<!--
| Workload | Before | After | Delta | Hardware |
|----------|--------|-------|-------|----------|
|          |        |       |       |          |

Commands run:
```
```
-->

## Checklist
- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] New code has unit tests (and property tests if touching storage/query)
- [ ] Docs updated (user docs under `docs/`, rustdoc on public items)
- [ ] ADR added if this changes architecture (link: `docs/architecture/adr/NNNN-*.md`)
- [ ] No new `unsafe` without an allowlist entry
- [ ] PR is scoped to a single logical change
