### PR TITLE
ci(bench): add nightly self-hosted gate + PR iai regression gate

### DIFF
--- a/.github/scripts/bench-collect-iai.sh
+++ b/.github/scripts/bench-collect-iai.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# bench-collect-iai.sh — capture iai-callgrind instruction counts into per-bench files.
+#
+# Usage:
+#   bench-collect-iai.sh <dest_dir>
+#
+# Reads `target/iai-run.txt` (captured stdout of `just bench-iai`) and writes
+# one file per bench: <dest_dir>/<bench_path>.ir containing just the
+# instruction count as a single integer.
+#
+# Parsing rather than JSON because the iai-callgrind JSON schema has shifted
+# between versions; the human-readable output is the stable contract.
+
+set -euo pipefail
+
+DEST="${1:?usage: $0 <dest_dir>}"
+SRC="${2:-target/iai-run.txt}"
+
+mkdir -p "$DEST"
+
+if [ ! -f "$SRC" ]; then
+  echo "bench-collect-iai: no iai output at $SRC — nothing to collect" >&2
+  exit 0
+fi
+
+# awk extracts: non-indented "foo::bar::baz" header, then the first integer
+# before the `|` on the next line starting with "  Instructions:".
+awk '
+  /^[A-Za-z_][A-Za-z0-9_]*(::[A-Za-z0-9_]+)+[[:space:]]*$/ {
+    gsub(/[[:space:]]+$/, "")
+    current = $0
+    next
+  }
+  /^[[:space:]]+Instructions:/ {
+    line = $0
+    sub(/^[[:space:]]+Instructions:[[:space:]]+/, "", line)
+    split(line, arr, "|")
+    gsub(/[^0-9]/, "", arr[1])
+    if (current != "" && arr[1] != "") {
+      print current "=" arr[1]
+    }
+  }
+' "$SRC" | while IFS='=' read -r key ir; do
+  [ -z "$key" ] && continue
+  safe=$(echo "$key" | tr -c 'A-Za-z0-9_:-' '_')
+  echo "$ir" > "$DEST/${safe}.ir"
+done
+
+count=$(ls -1 "$DEST"/*.ir 2>/dev/null | wc -l)
+echo "bench-collect-iai: collected $count benches into $DEST"
+if [ "$count" -eq 0 ]; then
+  echo "WARNING: no benches matched. Dumping $SRC head:" >&2
+  head -n 50 "$SRC" >&2 || true
+fi

--- a/.github/scripts/bench-compare-iai.sh
+++ b/.github/scripts/bench-compare-iai.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bench-compare-iai.sh — compare two sets of .ir files, post PR comment, gate on threshold.
+#
+# Usage:
+#   bench-compare-iai.sh <base_dir> <pr_dir>
+#
+# Env:
+#   REGRESSION_THRESHOLD  Max allowed positive delta in percent (default 2.0)
+#   PR_NUMBER             PR to comment on (optional — comment skipped if unset)
+#   GH_TOKEN              Required for posting the comment
+#
+# Exits non-zero if any bench regresses by more than REGRESSION_THRESHOLD.
+
+set -euo pipefail
+
+BASE_DIR="${1:?usage: $0 <base_dir> <pr_dir>}"
+PR_DIR="${2:?}"
+THRESHOLD="${REGRESSION_THRESHOLD:-2.0}"
+
+COMMENT=$(mktemp)
+trap 'rm -f "$COMMENT"' EXIT
+
+{
+  echo "## bench-regression — iai instruction counts"
+  echo
+  echo "| Benchmark | Base | PR | Δ | Verdict |"
+  echo "|-----------|-----:|---:|--:|:-------:|"
+} > "$COMMENT"
+
+regressed=0
+compared=0
+new_benches=()
+
+for pr_file in "$PR_DIR"/*.ir; do
+  [ -f "$pr_file" ] || continue
+  key=$(basename "$pr_file" .ir)
+  pr_val=$(tr -d '[:space:]' < "$pr_file")
+  base_file="$BASE_DIR/$key.ir"
+
+  if [ -f "$base_file" ]; then
+    base_val=$(tr -d '[:space:]' < "$base_file")
+    compared=$((compared + 1))
+    if [ -n "$base_val" ] && [ "$base_val" != "0" ]; then
+      delta=$(awk -v a="$base_val" -v b="$pr_val" 'BEGIN {printf "%+.2f", (b-a)*100/a}')
+      if awk -v d="$delta" -v t="$THRESHOLD" 'BEGIN {exit !(d+0 > t+0)}'; then
+        verdict="❌"
+        regressed=$((regressed + 1))
+      else
+        verdict="✅"
+      fi
+    else
+      delta="n/a"
+      verdict="—"
+    fi
+    printf "| \`%s\` | %s | %s | %s%% | %s |\n" \
+      "$key" "$base_val" "$pr_val" "$delta" "$verdict" >> "$COMMENT"
+  else
+    new_benches+=("$key")
+    printf "| \`%s\` | _new_ | %s | — | 🆕 |\n" "$key" "$pr_val" >> "$COMMENT"
+  fi
+done
+
+echo >> "$COMMENT"
+if [ "$compared" -eq 0 ] && [ "${#new_benches[@]}" -eq 0 ]; then
+  echo "_No iai benches captured. Check that \`just bench-iai\` ran and produced output._" >> "$COMMENT"
+elif [ "$compared" -eq 0 ]; then
+  echo "_No base-branch benches — all benches are new. Regression check skipped this run; baseline will populate on merge._" >> "$COMMENT"
+elif [ "$regressed" -gt 0 ]; then
+  echo "**Verdict:** ❌ FAIL — $regressed bench(es) regressed by more than +${THRESHOLD}% (AGENTS.md §5)." >> "$COMMENT"
+else
+  echo "**Verdict:** ✅ PASS (threshold: +${THRESHOLD}%)" >> "$COMMENT"
+fi
+
+echo "---"
+cat "$COMMENT"
+echo "---"
+
+if [ -n "${PR_NUMBER:-}" ] && command -v gh >/dev/null 2>&1; then
+  # Try edit-last to keep the conversation tidy; fall back to new comment.
+  gh pr comment "$PR_NUMBER" --body-file "$COMMENT" --edit-last \
+    || gh pr comment "$PR_NUMBER" --body-file "$COMMENT"
+fi
+
+if [ "$regressed" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/scripts/bench-package-results.sh
+++ b/.github/scripts/bench-package-results.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# bench-package-results.sh — package nightly bench output into a time-series JSON
+# to be published to gh-pages:bench-history/.
+#
+# Usage:
+#   bench-package-results.sh <output_dir>
+#
+# Reads:
+#   <output_dir>/hardware.env   (key=value pairs from bench-nightly.yml)
+#   target/iai-run.txt          (captured stdout of `just bench-iai`)
+#   target/criterion/           (cargo-criterion raw output, if present)
+#
+# Writes:
+#   <output_dir>/publish/<YYYY-MM-DD>-<short-sha>.json
+#   <output_dir>/publish/latest.json   (copy for dashboard convenience)
+
+set -euo pipefail
+
+OUT="${1:?usage: $0 <output_dir>}"
+PUBLISH="$OUT/publish"
+mkdir -p "$PUBLISH"
+
+# Load hardware context
+if [ -f "$OUT/hardware.env" ]; then
+  # shellcheck disable=SC1090
+  set -a; . "$OUT/hardware.env"; set +a
+fi
+
+SHA="${commit:-${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
+SHORT_SHA="${SHA:0:7}"
+DATE_UTC="${date:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+DAY_UTC=$(date -u +%Y-%m-%d -d "$DATE_UTC" 2>/dev/null || date -u +%Y-%m-%d)
+
+# Collect iai instruction counts into a temp dir, then fold into JSON
+IAI_TMP=$(mktemp -d)
+trap 'rm -rf "$IAI_TMP"' EXIT
+bash "$(dirname "$0")/bench-collect-iai.sh" "$IAI_TMP" "${IAI_SRC:-target/iai-run.txt}" || true
+
+# Build iai JSON: { bench_name: instruction_count, ... }
+iai_json="{}"
+if compgen -G "$IAI_TMP"/*.ir >/dev/null; then
+  iai_json=$(
+    for f in "$IAI_TMP"/*.ir; do
+      k=$(basename "$f" .ir)
+      v=$(tr -d '[:space:]' < "$f")
+      printf '{"%s":%s}\n' "$k" "${v:-null}"
+    done | jq -s 'add // {}'
+  )
+fi
+
+# Criterion is best-effort — we only record that results exist; full parse lives in the dashboard later.
+criterion_json='null'
+if [ -d target/criterion ]; then
+  estimates_count=$(find target/criterion -name estimates.json 2>/dev/null | wc -l)
+  criterion_json=$(jq -n --argjson n "$estimates_count" '{targets_with_estimates: $n}')
+fi
+
+jq -n \
+  --arg schema "physa-db.bench-history.v1" \
+  --arg commit "$SHA" \
+  --arg ref "${ref:-unknown}" \
+  --arg date "$DATE_UTC" \
+  --arg kernel "${kernel:-unknown}" \
+  --arg cpu "${cpu:-unknown}" \
+  --argjson cores "${cores:-0}" \
+  --argjson mem_kb "${mem_kb:-0}" \
+  --arg rustc "${rustc:-unknown}" \
+  --argjson iai "$iai_json" \
+  --argjson criterion "$criterion_json" \
+  '{
+    schema: $schema,
+    commit: $commit,
+    ref: $ref,
+    date: $date,
+    hardware: {
+      kernel: $kernel,
+      cpu: $cpu,
+      cores: $cores,
+      mem_kb: $mem_kb,
+      rustc: $rustc
+    },
+    iai: $iai,
+    criterion: $criterion
+  }' > "$PUBLISH/${DAY_UTC}-${SHORT_SHA}.json"
+
+cp "$PUBLISH/${DAY_UTC}-${SHORT_SHA}.json" "$PUBLISH/latest.json"
+
+echo "bench-package-results: wrote $PUBLISH/${DAY_UTC}-${SHORT_SHA}.json"
+ls -la "$PUBLISH/"

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -1,0 +1,93 @@
+name: bench-nightly
+
+# Nightly baseline run on the dedicated self-hosted bench runner.
+# Appends time-series JSON to the `gh-pages` branch under `bench-history/`.
+#
+# Why self-hosted: criterion wall-clock numbers on GitHub's shared ubuntu-latest
+# runners have 5-10% variance, which is larger than our regression threshold.
+# The self-hosted runner is pinned hardware with no competing workloads.
+#
+# Why not on PRs: running user-controlled code on a self-hosted runner from a
+# public repo is a well-known security footgun. The PR gate uses
+# bench-regression.yml on ubuntu-latest with iai-callgrind (deterministic,
+# so hardware variance doesn't matter).
+
+on:
+  schedule:
+    - cron: "30 3 * * *"   # 03:30 UTC nightly
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**/benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/bench-nightly.yml"
+      - ".github/scripts/bench-*.sh"
+
+permissions:
+  contents: write   # to push to gh-pages branch
+
+concurrency:
+  group: bench-nightly
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    name: nightly bench (iai + criterion)
+    runs-on: [self-hosted, bench, physa-db]
+    timeout-minutes: 90
+
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      # Ensure cargo/rustup are on PATH for non-login shells used by actions.
+      PATH: /home/github-runner/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Record hardware context
+        id: hw
+        run: |
+          mkdir -p bench-output
+          {
+            echo "commit=${{ github.sha }}"
+            echo "ref=${{ github.ref }}"
+            echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "kernel=$(uname -r)"
+            echo "cpu=$(lscpu | awk -F: '/Model name/ {gsub(/^ +/, "", $2); print $2; exit}')"
+            echo "cores=$(nproc)"
+            echo "mem_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)"
+            echo "rustc=$(rustc --version)"
+          } | tee bench-output/hardware.env
+
+      - name: Run iai (instruction-stable oracle)
+        run: |
+          mkdir -p target
+          just bench-iai 2>&1 | tee target/iai-run.txt
+
+      - name: Run criterion (wall-time time-series)
+        run: just bench
+        continue-on-error: true   # criterion noise shouldn't break the nightly archive
+
+      - name: Package results into time-series JSON
+        run: bash .github/scripts/bench-package-results.sh bench-output
+
+      - name: Upload raw bench artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-nightly-${{ github.sha }}
+          path: bench-output/
+          retention-days: 30
+
+      - name: Publish JSON to gh-pages:bench-history/
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./bench-output/publish
+          destination_dir: bench-history
+          keep_files: true
+          commit_message: "bench-nightly: ${{ github.sha }}"
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -1,53 +1,92 @@
 name: bench-regression
 
+# PR-time regression gate (AGENTS.md §5).
+#
+# Uses iai-callgrind as the regression oracle. Instruction counts are
+# deterministic across runs on the same binary, so this gate can safely
+# run on GitHub's shared ubuntu-latest — no self-hosted needed.
+#
+# Triggers:
+#   - PRs labelled `type:perf` (formal perf work must gate on numbers)
+#   - PRs that touch any `benches/` file (new/changed bench means new/changed gate)
+
 on:
   pull_request:
+    types: [labeled, synchronize, opened, reopened]
     paths:
-      - "crates/**"
-      - "benchmarks/**"
+      - "crates/**/benches/**"
+      - "crates/**/src/**"
       - "Cargo.toml"
       - "Cargo.lock"
-  schedule:
-    - cron: "30 3 * * *"
-  workflow_dispatch:
+      - ".github/workflows/bench-regression.yml"
+      - ".github/scripts/bench-*.sh"
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: bench-${{ github.ref }}
+  group: bench-regression-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  criterion:
-    name: criterion micro-benches
-    # Dedicated bench runner (self-hosted, pinned hardware) should be attached later.
-    # For now, ubuntu-latest is the placeholder so the workflow is wired up.
+  iai:
+    # Skip unless the PR is explicitly labelled type:perf or changes benches.
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'type:perf') ||
+      contains(github.event.pull_request.changed_files.*.filename, '/benches/')
+    name: iai instruction-count gate
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    env:
+      CARGO_TERM_COLOR: always
+      REGRESSION_THRESHOLD: "2.0"
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: bench-regression
 
-      - name: Install cargo-criterion
-        run: cargo install cargo-criterion --version 1.1
-
-      - name: Fetch baseline from main
+      - name: Install valgrind + iai-callgrind-runner
         run: |
-          git fetch origin main:main
-          git worktree add /tmp/baseline main
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends valgrind
+          cargo install iai-callgrind-runner --version ^0.14 --locked
 
-      - name: Run baseline benches (main)
-        working-directory: /tmp/baseline
-        run: cargo criterion --workspace -- --save-baseline main || echo "No benches on main yet"
+      # ----------- PR HEAD -----------
+      - name: Run iai on PR HEAD
+        run: |
+          mkdir -p target
+          just bench-iai 2>&1 | tee target/iai-pr.txt
 
-      - name: Run PR benches
-        run: cargo criterion --workspace -- --baseline main || echo "Baseline not populated yet"
+      - name: Collect PR summaries
+        run: bash .github/scripts/bench-collect-iai.sh pr-summaries target/iai-pr.txt
 
-      - name: Post comparison comment (placeholder)
-        if: github.event_name == 'pull_request'
-        run: echo "TODO: parse criterion JSON and post comment via gh api"
+      # ----------- BASE (main) -----------
+      - name: Checkout base branch
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git checkout ${{ github.event.pull_request.base.ref }}
+
+      - name: Run iai on base
+        run: |
+          just bench-iai 2>&1 | tee target/iai-base.txt
+        continue-on-error: true   # base may not yet have benches
+
+      - name: Collect base summaries
+        run: bash .github/scripts/bench-collect-iai.sh base-summaries target/iai-base.txt
+
+      # ----------- COMPARE -----------
+      - name: Compare PR vs base, post comment, enforce threshold
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: bash .github/scripts/bench-compare-iai.sh base-summaries pr-summaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,16 +110,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -151,6 +205,100 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -212,6 +360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +392,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "iai-callgrind"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9e864ad001cbbf35a64f7b574998823b8622bb483a25246fa1b0e2b3888686"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cee6c3bc32b63ff40e5e56190b1276d2bd0e0b319aa6f998864c27865d3b4e"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82491521e6505b06a824274712a1307904e7cdfdf047735f7dfdb28b5f7a337"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,16 +452,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -358,6 +589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +651,8 @@ dependencies = [
 name = "physa-core"
 version = "0.0.0"
 dependencies = [
+ "criterion",
+ "iai-callgrind",
  "proptest",
  "serde",
  "thiserror",
@@ -448,6 +687,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +730,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -560,12 +849,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -586,6 +907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +944,15 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -760,6 +1105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,6 +1243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1274,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -943,6 +1353,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/crates/physa-core/Cargo.toml
+++ b/crates/physa-core/Cargo.toml
@@ -18,3 +18,13 @@ serde = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
+criterion = { workspace = true }
+iai-callgrind = { workspace = true }
+
+[[bench]]
+name = "smoke"
+harness = false
+
+[[bench]]
+name = "iai"
+harness = false

--- a/crates/physa-core/benches/iai.rs
+++ b/crates/physa-core/benches/iai.rs
@@ -1,0 +1,31 @@
+//! iai-callgrind instruction-count smoke bench.
+//!
+//! This is the regression oracle for the `bench-regression` PR gate
+//! (AGENTS.md §5). Instruction counts are deterministic across runs on
+//! the same binary — the gate fires when `delta > 2%`.
+//!
+//! Scaffolding only; grow the list of tracked benches as `physa-core`
+//! adds measurable code paths.
+
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+
+#[library_benchmark]
+fn smoke_noop() -> u64 {
+    std::hint::black_box(0_u64)
+}
+
+#[library_benchmark]
+fn smoke_sum_1024() -> u64 {
+    let mut acc: u64 = 0;
+    for i in 0..1024_u64 {
+        acc = acc.wrapping_add(std::hint::black_box(i));
+    }
+    acc
+}
+
+library_benchmark_group!(
+    name = smoke;
+    benchmarks = smoke_noop, smoke_sum_1024
+);
+
+main!(library_benchmark_groups = smoke);

--- a/crates/physa-core/benches/smoke.rs
+++ b/crates/physa-core/benches/smoke.rs
@@ -1,0 +1,27 @@
+//! Criterion wall-time smoke bench.
+//!
+//! Scaffolding only: ensures the `bench-nightly` pipeline has something to
+//! measure before real storage/query benchmarks land. Replace with real
+//! benches as `physa-core` grows; do not delete the file — the CI workflow
+//! expects at least one criterion target.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+fn smoke_noop(c: &mut Criterion) {
+    c.bench_function("smoke_noop", |b| b.iter(|| black_box(0_u64)));
+}
+
+fn smoke_sum_1024(c: &mut Criterion) {
+    c.bench_function("smoke_sum_1024", |b| {
+        b.iter(|| {
+            let mut acc: u64 = 0;
+            for i in 0..1024_u64 {
+                acc = acc.wrapping_add(black_box(i));
+            }
+            acc
+        });
+    });
+}
+
+criterion_group!(smoke, smoke_noop, smoke_sum_1024);
+criterion_main!(smoke);

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -58,6 +58,124 @@ It will fail loudly if anything under `private/` is staged.
 - **Bench numbers unstable** → use `just bench-iai` for instruction-count benches; they're stable across hardware.
 - **Fuzz targets missing** → they live under `fuzz/` (created in M2+); list with `cargo fuzz list`.
 
+## Self-hosted bench runner
+
+The nightly bench gate (`.github/workflows/bench-nightly.yml`) runs on a
+dedicated self-hosted runner. Wall-clock numbers from GitHub's shared
+runners have 5-10 % variance, which is larger than our +2 % regression
+threshold (AGENTS.md §5), so wall-clock work needs pinned hardware.
+
+The PR gate (`.github/workflows/bench-regression.yml`) runs on
+`ubuntu-latest` because it uses iai-callgrind (instruction counts,
+deterministic across hosts). Self-hosted + public repo is a known
+security risk and is intentionally avoided for PR-triggered runs.
+
+### Runner spec
+
+| Field | Baseline |
+|-------|----------|
+| OS | Ubuntu 24.04 LTS |
+| CPU | ≥ 4 physical cores, x86_64 |
+| RAM | ≥ 7 GB |
+| Disk | ≥ 20 GB free for Cargo cache + target/ |
+| Labels | `self-hosted`, `bench`, `physa-db` (plus auto-added `Linux`, `X64`) |
+| Runner mode | `--ephemeral` (auto-deregister after each job) |
+| Runner user | dedicated non-root system user (e.g. `github-runner`) |
+
+### Provisioning (one-time)
+
+1. Pick a host that is not shared with user workloads. If it also hosts
+   another CI (GitLab runner, Buildkite, …), give each CI its own user
+   and let them cohabit on separate home directories.
+2. Create a system user with a shell and home:
+   ```bash
+   sudo adduser --system --group --shell /bin/bash --home /home/github-runner github-runner
+   ```
+3. Install build dependencies (`valgrind` is required for iai-callgrind):
+   ```bash
+   sudo apt-get install -y --no-install-recommends \
+     valgrind build-essential pkg-config libssl-dev ca-certificates curl git
+   ```
+4. Install Rust for the runner user:
+   ```bash
+   sudo -u github-runner -H bash -c '
+     curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | \
+       sh -s -- -y --default-toolchain stable --profile minimal \
+       --component rustfmt --component clippy --no-modify-path
+   '
+   ```
+5. Install the Cargo helpers used by `just bench` and `just bench-iai`:
+   ```bash
+   sudo -u github-runner -H bash -lc '
+     export PATH=/home/github-runner/.cargo/bin:$PATH
+     cargo install cargo-criterion --version ^1.1 --locked
+     cargo install iai-callgrind-runner --version ^0.14 --locked
+   '
+   ```
+6. Download and register the GitHub Actions runner binary:
+   ```bash
+   RUNNER_VERSION=$(curl -s https://api.github.com/repos/actions/runner/releases/latest \
+     | grep -oP '"tag_name": "v\K[^"]+')
+   sudo -u github-runner -H bash -c "
+     mkdir -p /home/github-runner/actions-runner
+     cd /home/github-runner/actions-runner
+     curl -sSL -o runner.tar.gz \
+       https://github.com/actions/runner/releases/download/v\${RUNNER_VERSION}/actions-runner-linux-x64-\${RUNNER_VERSION}.tar.gz
+     tar xzf runner.tar.gz && rm runner.tar.gz
+   "
+   sudo /home/github-runner/actions-runner/bin/installdependencies.sh
+   ```
+7. Generate a registration token from a host that can auth to GitHub as
+   a repo admin:
+   ```bash
+   gh api -X POST repos/mroche14/physa-db/actions/runners/registration-token --jq .token
+   ```
+   The token is valid for ~1 h and one-shot.
+8. Configure the runner (on the runner host), replacing `<TOKEN>`:
+   ```bash
+   sudo -u github-runner -H bash -c '
+     cd /home/github-runner/actions-runner
+     ./config.sh --unattended --ephemeral \
+       --url https://github.com/mroche14/physa-db \
+       --token <TOKEN> \
+       --labels self-hosted,bench,physa-db \
+       --name physa-db-bench-01 \
+       --replace
+   '
+   ```
+9. Install and start the systemd service:
+   ```bash
+   cd /home/github-runner/actions-runner
+   sudo ./svc.sh install github-runner
+   sudo ./svc.sh start
+   ```
+10. Verify from GitHub:
+    ```bash
+    gh api repos/mroche14/physa-db/actions/runners \
+      --jq '.runners[] | {name, status, labels: [.labels[].name]}'
+    ```
+    Expect `"status": "online"` and the three custom labels.
+
+### Troubleshooting
+
+- **Runner stuck in `offline`** → `sudo systemctl status actions.runner.mroche14-physa-db.*` and `journalctl -u actions.runner.mroche14-physa-db.* -n 200`.
+- **`config.sh` says "Failed to create self-hosted runner"** → token expired (>1 h since issue) or no admin rights. Regenerate via `gh api`.
+- **`bench-nightly` fails with `no bench target named iai`** → the crate was removed from the `just bench-iai` recipe list; re-add it.
+- **iai-callgrind reports `No version information found`** → missing `iai-callgrind` dev-dep in the bench's `Cargo.toml`.
+- **Disk fills up** → `target/` caches accumulate. `sudo -u github-runner cargo clean` or prune old `_work/` subtrees under `/home/github-runner/actions-runner/_work/`.
+
+### Decommissioning
+
+```bash
+cd /home/github-runner/actions-runner
+sudo ./svc.sh stop
+sudo ./svc.sh uninstall
+sudo -u github-runner ./config.sh remove --token <REMOVAL_TOKEN>
+```
+
+The removal token is fetched the same way as the registration token but
+via `remove-token` instead of `registration-token`.
+
 ## Onboarding for AI agents
 
 Read `AGENTS.md` in full, then pick an issue labelled `status:ready` + `agent:good-first-task`. The rest of the workflow is in `AGENTS.md` §§3, 8, 9.

--- a/justfile
+++ b/justfile
@@ -58,8 +58,11 @@ bench-save baseline="current":
     cargo criterion --workspace -- --save-baseline {{baseline}}
 
 # Instruction-count benches (stable across hardware, good for CI gates).
+# List each crate that ships an `iai` bench target explicitly — cargo errors
+# on `--workspace --bench iai` if any member lacks that target. Add crates
+# here as they grow an `iai.rs` under their `benches/` directory.
 bench-iai:
-    cargo bench --bench iai --workspace
+    cargo bench -p physa-core --bench iai
 
 # Macro benchmarks (LDBC SNB / SNAP) on SF1.
 bench-macro sf="1":


### PR DESCRIPTION
## Summary

Implements the full bench-regression stack from AGENTS.md §5 (closes #5).

- **PR gate** (`bench-regression.yml`) — runs on `ubuntu-latest` using iai-callgrind (instruction counts, deterministic). Fires on `type:perf` PRs or any change under `crates/**/benches/**`. Posts a delta table as a PR comment and fails if any bench regresses > 2 %.
- **Nightly gate** (`bench-nightly.yml`) — runs on the dedicated self-hosted runner (`self-hosted,bench,physa-db`, `--ephemeral`). Captures both iai and criterion results and publishes a schema-versioned JSON (`physa-db.bench-history.v1`) to `gh-pages:bench-history/<YYYY-MM-DD>-<sha>.json`.
- **Security split** — self-hosted never runs PR-triggered jobs (schedule/push-main only). iai's determinism means the PR gate is noise-free even on shared runners.

## Implementation notes

- `just bench-iai` explicitly lists crates with an `iai` bench target (cargo errors on `--workspace --bench iai` if any member lacks it).
- Smoke benches in `physa-core` (`smoke.rs` criterion, `iai.rs` iai-callgrind) are scaffolding to validate the pipeline end-to-end. Replace as real benches land.
- `bench-collect-iai.sh` parses iai stdout (rather than its evolving JSON schema) for robustness; `bench-compare-iai.sh` edits the PR comment in place via `gh pr comment --edit-last`.
- `docs/dev-setup.md` gains a full self-hosted runner playbook (spec, provisioning, troubleshooting, decommission).

## Self-hosted runner status

Configured on `smartbeez-builder` (Ubuntu 24.04, 4 cores, 7.6 GB RAM) alongside the existing GitLab runner under a dedicated non-root `github-runner` user. `systemctl` service active, labels confirmed via `gh api`: `[self-hosted, Linux, X64, bench, physa-db]`.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (0 tests — no suite yet)
- [x] `cargo bench --no-run -p physa-core --bench {iai,smoke}` build
- [x] `bash -n` on all three `.github/scripts/*.sh`
- [ ] Observe nightly bench run after merge (cron 03:30 UTC) — publishes first JSON under `gh-pages:bench-history/`
- [ ] Open a follow-up PR with the `type:perf` label to exercise the regression gate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)