### PR TITLE
feat(xtask): implement real snapshot-dashboard generator

### DIFF
--- a/.github/workflows/snapshot-dashboard.yml
+++ b/.github/workflows/snapshot-dashboard.yml
@@ -38,23 +38,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+          shared-key: xtask
+
       - name: Build state.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p dashboard/data
-          # Placeholder: this script will call the GitHub REST/GraphQL API
-          # and produce dashboard/data/state.json matching the schema in
-          # dashboard/src/app.js.
-          # Owned by the `scripts/build-dashboard-snapshot.sh` issue (to be filed).
-          cat > dashboard/data/state.json <<'JSON'
-          {
-            "generatedAt": "1970-01-01T00:00:00Z",
-            "stats": { "openIssues": 0, "inProgress": 0, "doneLast30d": 0, "currentMilestone": "M0" },
-            "milestones": [],
-            "activity": []
-          }
-          JSON
+          PHYSA_SNAPSHOT_OWNER: ${{ github.repository_owner }}
+          PHYSA_SNAPSHOT_REPO: ${{ github.event.repository.name }}
+        run: cargo run --release -p xtask -- snapshot-dashboard
 
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +577,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +728,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1105,6 +1126,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1543,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/xtask/src/dashboard/fetch.rs
+++ b/xtask/src/dashboard/fetch.rs
@@ -1,0 +1,304 @@
+//! GraphQL queries + pagination. Parses the raw `serde_json::Value`
+//! responses into internal node types consumed by `snapshot.rs`.
+//!
+//! The queries are intentionally narrow — we ask for exactly the fields
+//! the `state.json` schema needs, nothing more. Adding a field here is
+//! cheap; adding one we don't use inflates rate-limit cost.
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+
+use super::gh::GraphQLFetcher;
+
+#[derive(Debug)]
+pub struct Fetched {
+    pub issues: Vec<IssueNode>,
+    pub pulls: Vec<PullNode>,
+    pub milestones: Vec<MilestoneNode>,
+    pub project_items: Option<Vec<ProjectItemNode>>,
+}
+
+#[derive(Debug)]
+pub struct IssueNode {
+    pub title: String,
+    pub url: String,
+    pub state: String,
+    pub created_at: String,
+    pub closed_at: Option<String>,
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct PullNode {
+    pub title: String,
+    pub url: String,
+    pub state: String,
+    pub created_at: String,
+    pub closed_at: Option<String>,
+    pub merged_at: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct MilestoneNode {
+    pub title: String,
+    pub state: String,
+    pub due_on: Option<String>,
+    pub open_issue_count: u32,
+    pub closed_issue_count: u32,
+}
+
+#[derive(Debug)]
+pub struct ProjectItemNode {
+    pub status: Option<String>,
+}
+
+const ISSUES_QUERY: &str = r"
+query($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    issues(first:100, after:$cursor, states:[OPEN, CLOSED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        title url state createdAt closedAt
+        labels(first:20) { nodes { name } }
+      }
+    }
+  }
+}";
+
+const PULLS_QUERY: &str = r"
+query($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequests(first:100, after:$cursor, states:[OPEN, CLOSED, MERGED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes { title url state createdAt closedAt mergedAt }
+    }
+  }
+}";
+
+const MILESTONES_QUERY: &str = r"
+query($owner:String!, $repo:String!) {
+  repository(owner:$owner, name:$repo) {
+    milestones(first:50, states:[OPEN, CLOSED], orderBy:{field:DUE_DATE, direction:ASC}) {
+      nodes { title state dueOn openIssueCount closedIssueCount }
+    }
+  }
+}";
+
+const PROJECTS_QUERY: &str = r"
+query($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    projectsV2(first:1) {
+      nodes {
+        number
+        items(first:100, after:$cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            fieldValues(first:20) {
+              nodes {
+                __typename
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field { ... on ProjectV2SingleSelectField { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}";
+
+pub fn fetch_all(f: &dyn GraphQLFetcher, owner: &str, repo: &str) -> Result<Fetched> {
+    Ok(Fetched {
+        issues: fetch_issues(f, owner, repo)?,
+        pulls: fetch_pulls(f, owner, repo)?,
+        milestones: fetch_milestones(f, owner, repo)?,
+        project_items: fetch_project_items(f, owner, repo)?,
+    })
+}
+
+fn fetch_issues(f: &dyn GraphQLFetcher, owner: &str, repo: &str) -> Result<Vec<IssueNode>> {
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut page = 1;
+    loop {
+        let vars = json!({ "owner": owner, "repo": repo, "cursor": cursor });
+        let label = format!("issues_p{page}");
+        let resp = f.run(&label, ISSUES_QUERY, &vars)?;
+        let root = resp
+            .pointer("/data/repository/issues")
+            .context("issues: missing repository.issues")?;
+        for node in root["nodes"].as_array().unwrap_or(&vec![]) {
+            out.push(parse_issue(node)?);
+        }
+        if !page_has_next(root) {
+            break;
+        }
+        cursor = page_end_cursor(root).map(str::to_string);
+        page += 1;
+    }
+    Ok(out)
+}
+
+fn fetch_pulls(f: &dyn GraphQLFetcher, owner: &str, repo: &str) -> Result<Vec<PullNode>> {
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut page = 1;
+    loop {
+        let vars = json!({ "owner": owner, "repo": repo, "cursor": cursor });
+        let label = format!("pulls_p{page}");
+        let resp = f.run(&label, PULLS_QUERY, &vars)?;
+        let root = resp
+            .pointer("/data/repository/pullRequests")
+            .context("pulls: missing repository.pullRequests")?;
+        for node in root["nodes"].as_array().unwrap_or(&vec![]) {
+            out.push(parse_pull(node)?);
+        }
+        if !page_has_next(root) {
+            break;
+        }
+        cursor = page_end_cursor(root).map(str::to_string);
+        page += 1;
+    }
+    Ok(out)
+}
+
+fn fetch_milestones(f: &dyn GraphQLFetcher, owner: &str, repo: &str) -> Result<Vec<MilestoneNode>> {
+    let vars = json!({ "owner": owner, "repo": repo });
+    let resp = f.run("milestones", MILESTONES_QUERY, &vars)?;
+    let mut out = Vec::new();
+    for node in resp
+        .pointer("/data/repository/milestones/nodes")
+        .and_then(Value::as_array)
+        .context("milestones: missing repository.milestones.nodes")?
+    {
+        out.push(parse_milestone(node)?);
+    }
+    Ok(out)
+}
+
+fn fetch_project_items(
+    f: &dyn GraphQLFetcher,
+    owner: &str,
+    repo: &str,
+) -> Result<Option<Vec<ProjectItemNode>>> {
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut page = 1;
+    loop {
+        let vars = json!({ "owner": owner, "repo": repo, "cursor": cursor });
+        let label = format!("projects_p{page}");
+        let resp = f.run(&label, PROJECTS_QUERY, &vars)?;
+        let projects = resp
+            .pointer("/data/repository/projectsV2/nodes")
+            .and_then(Value::as_array);
+        let Some(project) = projects.and_then(|v| v.first()) else {
+            return Ok(None);
+        };
+        let items = project
+            .pointer("/items")
+            .context("projects_v2: missing items")?;
+        for node in items["nodes"].as_array().unwrap_or(&vec![]) {
+            out.push(parse_project_item(node));
+        }
+        if !page_has_next(items) {
+            break;
+        }
+        cursor = page_end_cursor(items).map(str::to_string);
+        page += 1;
+    }
+    Ok(Some(out))
+}
+
+fn page_has_next(root: &Value) -> bool {
+    root.pointer("/pageInfo/hasNextPage")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn page_end_cursor(root: &Value) -> Option<&str> {
+    root.pointer("/pageInfo/endCursor").and_then(Value::as_str)
+}
+
+fn parse_issue(node: &Value) -> Result<IssueNode> {
+    Ok(IssueNode {
+        title: str_field(node, "title")?.to_string(),
+        url: str_field(node, "url")?.to_string(),
+        state: str_field(node, "state")?.to_string(),
+        created_at: str_field(node, "createdAt")?.to_string(),
+        closed_at: node
+            .get("closedAt")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        labels: node
+            .pointer("/labels/nodes")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|l| l.get("name").and_then(Value::as_str).map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    })
+}
+
+fn parse_pull(node: &Value) -> Result<PullNode> {
+    Ok(PullNode {
+        title: str_field(node, "title")?.to_string(),
+        url: str_field(node, "url")?.to_string(),
+        state: str_field(node, "state")?.to_string(),
+        created_at: str_field(node, "createdAt")?.to_string(),
+        closed_at: node
+            .get("closedAt")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        merged_at: node
+            .get("mergedAt")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+    })
+}
+
+fn parse_milestone(node: &Value) -> Result<MilestoneNode> {
+    Ok(MilestoneNode {
+        title: str_field(node, "title")?.to_string(),
+        state: str_field(node, "state")?.to_string(),
+        due_on: node
+            .get("dueOn")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        open_issue_count: u32_field(node, "openIssueCount"),
+        closed_issue_count: u32_field(node, "closedIssueCount"),
+    })
+}
+
+fn parse_project_item(node: &Value) -> ProjectItemNode {
+    let status = node
+        .pointer("/fieldValues/nodes")
+        .and_then(Value::as_array)
+        .and_then(|fvs| {
+            fvs.iter().find_map(|fv| {
+                let field_name = fv.pointer("/field/name").and_then(Value::as_str);
+                if field_name == Some("Status") {
+                    fv.get("name").and_then(Value::as_str).map(str::to_string)
+                } else {
+                    None
+                }
+            })
+        });
+    ProjectItemNode { status }
+}
+
+fn str_field<'a>(node: &'a Value, key: &str) -> Result<&'a str> {
+    node.get(key)
+        .and_then(Value::as_str)
+        .with_context(|| format!("missing field `{key}`"))
+}
+
+fn u32_field(node: &Value, key: &str) -> u32 {
+    node.get(key)
+        .and_then(Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok())
+        .unwrap_or(0)
+}

--- a/xtask/src/dashboard/gh.rs
+++ b/xtask/src/dashboard/gh.rs
@@ -1,0 +1,110 @@
+//! GraphQL fetcher abstraction with two implementations:
+//!
+//! - [`GhCli`] shells out to `gh api graphql --input -` (production).
+//! - [`FixtureFetcher`] reads pre-recorded JSON responses (tests).
+//!
+//! The trait keeps the snapshot pipeline hermetic — unit and integration
+//! tests never touch the network.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+pub trait GraphQLFetcher {
+    /// Run one GraphQL query. `label` disambiguates fixture lookups and
+    /// identifies the call in logs; production impls ignore it.
+    fn run(&self, label: &str, query: &str, variables: &Value) -> Result<Value>;
+}
+
+pub struct GhCli;
+
+impl GraphQLFetcher for GhCli {
+    fn run(&self, label: &str, query: &str, variables: &Value) -> Result<Value> {
+        tracing::debug!(label, "gh api graphql");
+        let payload = serde_json::json!({ "query": query, "variables": variables });
+        let mut child = Command::new("gh")
+            .args(["api", "graphql", "--input", "-"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("failed to spawn `gh`; install it or check $PATH")?;
+        {
+            let mut stdin = child.stdin.take().context("child stdin already closed")?;
+            stdin.write_all(&serde_json::to_vec(&payload)?)?;
+        }
+        let out = child.wait_with_output()?;
+        if !out.status.success() {
+            bail!(
+                "gh api graphql (label={label}) exited {:?}: {}",
+                out.status.code(),
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let json: Value =
+            serde_json::from_slice(&out.stdout).context("gh api graphql did not return JSON")?;
+        if let Some(errs) = json.get("errors") {
+            bail!("GraphQL errors (label={label}): {errs}");
+        }
+        Ok(json)
+    }
+}
+
+pub struct FixtureFetcher {
+    base: PathBuf,
+}
+
+impl FixtureFetcher {
+    pub fn new(base: impl Into<PathBuf>) -> Self {
+        Self { base: base.into() }
+    }
+}
+
+impl GraphQLFetcher for FixtureFetcher {
+    fn run(&self, label: &str, _query: &str, _variables: &Value) -> Result<Value> {
+        let path = self.base.join(format!("{label}.json"));
+        let bytes =
+            std::fs::read(&path).with_context(|| format!("fixture missing: {}", path.display()))?;
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("fixture not valid JSON: {}", path.display()))
+    }
+}
+
+/// Resolve `(owner, repo)` from `gh repo view --json owner,name`.
+///
+/// This is the same source of truth `gh` uses everywhere, so a contributor
+/// working on a fork sees their fork's data. Falls back to env overrides
+/// `PHYSA_SNAPSHOT_OWNER` / `PHYSA_SNAPSHOT_REPO` to help CI pin a target.
+pub fn resolve_repo() -> Result<(String, String)> {
+    if let (Ok(owner), Ok(repo)) = (
+        std::env::var("PHYSA_SNAPSHOT_OWNER"),
+        std::env::var("PHYSA_SNAPSHOT_REPO"),
+    ) {
+        return Ok((owner, repo));
+    }
+    let out = Command::new("gh")
+        .args(["repo", "view", "--json", "owner,name"])
+        .output()
+        .context("failed to run `gh repo view`")?;
+    if !out.status.success() {
+        bail!(
+            "`gh repo view` failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let v: Value = serde_json::from_slice(&out.stdout)?;
+    let owner = v
+        .pointer("/owner/login")
+        .and_then(Value::as_str)
+        .context("gh repo view: missing owner.login")?
+        .to_string();
+    let repo = v
+        .pointer("/name")
+        .and_then(Value::as_str)
+        .context("gh repo view: missing name")?
+        .to_string();
+    Ok((owner, repo))
+}

--- a/xtask/src/dashboard/mod.rs
+++ b/xtask/src/dashboard/mod.rs
@@ -1,0 +1,89 @@
+//! `snapshot-dashboard` xtask subcommand.
+//!
+//! Glues the GraphQL fetcher (`gh.rs`), the response parsing
+//! (`fetch.rs`), and the pure synthesis (`snapshot.rs`) into a single
+//! entry point invoked from `main.rs`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
+
+use self::fetch::Fetched;
+use self::gh::{GhCli, GraphQLFetcher, resolve_repo};
+
+pub mod fetch;
+pub mod gh;
+pub mod snapshot;
+pub mod state;
+
+const DEFAULT_OUTPUT: &str = "dashboard/data/state.json";
+const DONE_WINDOW_DAYS: i64 = 30;
+
+#[derive(Debug, Default)]
+pub struct Args {
+    pub dry_run: bool,
+    pub output: Option<PathBuf>,
+}
+
+pub fn run(args: &Args) -> Result<()> {
+    let (owner, repo) = resolve_repo()?;
+    tracing::info!(owner, repo, "snapshot-dashboard starting");
+
+    let now = resolve_now()?;
+    let cutoff = now - Duration::days(DONE_WINDOW_DAYS);
+    let now_rfc = now.format(&Rfc3339)?;
+    let cutoff_rfc = cutoff.format(&Rfc3339)?;
+
+    let client = GhCli;
+    let data = fetch::fetch_all(&client as &dyn GraphQLFetcher, &owner, &repo)?;
+    let state = snapshot::build_state(&data, &now_rfc, &cutoff_rfc);
+
+    let mut json = serde_json::to_string_pretty(&state)?;
+    json.push('\n');
+
+    if args.dry_run {
+        print!("{json}");
+    } else {
+        let path = args
+            .output
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT));
+        write_atomic(&path, json.as_bytes())?;
+        tracing::info!(path = %path.display(), "wrote state.json");
+    }
+    Ok(())
+}
+
+/// Run the pipeline against an arbitrary fetcher and clock — used by
+/// integration tests to replay recorded fixtures.
+pub fn build_from(
+    client: &dyn GraphQLFetcher,
+    owner: &str,
+    repo: &str,
+    now_rfc: &str,
+    cutoff_rfc: &str,
+) -> Result<(state::State, Fetched)> {
+    let data = fetch::fetch_all(client, owner, repo)?;
+    let state = snapshot::build_state(&data, now_rfc, cutoff_rfc);
+    Ok((state, data))
+}
+
+fn resolve_now() -> Result<OffsetDateTime> {
+    if let Ok(raw) = std::env::var("PHYSA_SNAPSHOT_NOW") {
+        return OffsetDateTime::parse(&raw, &Rfc3339)
+            .with_context(|| format!("PHYSA_SNAPSHOT_NOW is not RFC3339: {raw}"));
+    }
+    Ok(OffsetDateTime::now_utc())
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, bytes).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}

--- a/xtask/src/dashboard/snapshot.rs
+++ b/xtask/src/dashboard/snapshot.rs
@@ -1,0 +1,377 @@
+//! Pure synthesis: fetched GraphQL data + fixed `now` → [`State`].
+//!
+//! No I/O, no time source. `now_rfc3339` is injected so tests and CI
+//! runs are reproducible byte-for-byte.
+
+#[cfg(test)]
+use super::fetch::ProjectItemNode;
+use super::fetch::{Fetched, IssueNode, MilestoneNode, PullNode};
+use super::state::{ActivityEvent, Milestone, State, Stats};
+
+const IN_PROGRESS_LABEL: &str = "status:in-progress";
+const IN_PROGRESS_STATUS: &str = "In Progress";
+const ACTIVITY_CAP: usize = 50;
+
+#[must_use]
+pub fn build_state(fetched: &Fetched, now_rfc3339: &str, cutoff_30d_rfc3339: &str) -> State {
+    State {
+        generated_at: now_rfc3339.to_string(),
+        stats: build_stats(fetched, cutoff_30d_rfc3339),
+        milestones: build_milestones(&fetched.milestones),
+        activity: build_activity(&fetched.issues, &fetched.pulls),
+    }
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "a single repo will never carry more than u32::MAX issues"
+)]
+fn count_u32<T>(iter: impl Iterator<Item = T>) -> u32 {
+    iter.count() as u32
+}
+
+fn build_stats(f: &Fetched, cutoff: &str) -> Stats {
+    let open_issues = count_u32(f.issues.iter().filter(|i| i.state == "OPEN"));
+
+    // Label is the primary truth source per AGENTS.md §6.1 (agents flip
+    // `status:in-progress` on claim; Projects v2 Status is a human-viewed
+    // board field that is not always kept in sync by automation).
+    let in_progress = count_u32(
+        f.issues
+            .iter()
+            .filter(|i| i.state == "OPEN" && i.labels.iter().any(|l| l == IN_PROGRESS_LABEL)),
+    );
+
+    if let Some(items) = &f.project_items {
+        let pv2_in_progress = items
+            .iter()
+            .filter(|p| p.status.as_deref() == Some(IN_PROGRESS_STATUS))
+            .count();
+        tracing::debug!(
+            pv2_in_progress,
+            label_in_progress = in_progress,
+            "projects_v2 observed (not used for stats; labels are truth)"
+        );
+    }
+
+    let done_last_30d = count_u32(
+        f.issues
+            .iter()
+            .filter(|i| closed_since(i.closed_at.as_deref(), cutoff))
+            .map(|_| ())
+            .chain(
+                f.pulls
+                    .iter()
+                    .filter(|p| closed_since(p.merged_at.as_deref(), cutoff))
+                    .map(|_| ()),
+            ),
+    );
+
+    let current_milestone = f
+        .milestones
+        .iter()
+        .find(|m| m.state == "OPEN")
+        .map(|m| split_milestone(&m.title).0)
+        .unwrap_or_default();
+
+    Stats {
+        open_issues,
+        in_progress,
+        done_last_30d,
+        current_milestone,
+    }
+}
+
+fn build_milestones(raw: &[MilestoneNode]) -> Vec<Milestone> {
+    let mut out: Vec<Milestone> = raw
+        .iter()
+        .map(|m| {
+            let (name, title) = split_milestone(&m.title);
+            Milestone {
+                name,
+                title,
+                done: m.closed_issue_count,
+                total: m.open_issue_count + m.closed_issue_count,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn build_activity(issues: &[IssueNode], pulls: &[PullNode]) -> Vec<ActivityEvent> {
+    let mut events: Vec<ActivityEvent> = Vec::new();
+
+    for i in issues {
+        events.push(ActivityEvent {
+            at: i.created_at.clone(),
+            kind: "issue.opened".into(),
+            title: i.title.clone(),
+            url: i.url.clone(),
+        });
+        if let Some(at) = &i.closed_at {
+            events.push(ActivityEvent {
+                at: at.clone(),
+                kind: "issue.closed".into(),
+                title: i.title.clone(),
+                url: i.url.clone(),
+            });
+        }
+    }
+
+    for p in pulls {
+        events.push(ActivityEvent {
+            at: p.created_at.clone(),
+            kind: "pr.opened".into(),
+            title: p.title.clone(),
+            url: p.url.clone(),
+        });
+        if let Some(at) = &p.merged_at {
+            events.push(ActivityEvent {
+                at: at.clone(),
+                kind: "pr.merged".into(),
+                title: p.title.clone(),
+                url: p.url.clone(),
+            });
+        } else if let Some(at) = &p.closed_at {
+            events.push(ActivityEvent {
+                at: at.clone(),
+                kind: "pr.closed".into(),
+                title: p.title.clone(),
+                url: p.url.clone(),
+            });
+        }
+    }
+
+    events.sort_by(|a, b| {
+        b.at.cmp(&a.at)
+            .then_with(|| a.kind.cmp(&b.kind))
+            .then_with(|| a.url.cmp(&b.url))
+    });
+    events.truncate(ACTIVITY_CAP);
+    events
+}
+
+fn closed_since(when: Option<&str>, cutoff: &str) -> bool {
+    when.is_some_and(|w| w.as_bytes() >= cutoff.as_bytes())
+}
+
+/// Split a milestone title like `"M0 — Foundation"` into `("M0", "Foundation")`.
+/// Falls back to `(whole, "")` if no em-dash is present.
+fn split_milestone(raw: &str) -> (String, String) {
+    const EM_DASH: char = '\u{2014}';
+    raw.find(EM_DASH).map_or_else(
+        || (raw.trim().to_string(), String::new()),
+        |idx| {
+            let (name, rest) = raw.split_at(idx);
+            let title = rest[EM_DASH.len_utf8()..].trim();
+            (name.trim().to_string(), title.to_string())
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue(state: &str, created: &str, closed: Option<&str>, labels: &[&str]) -> IssueNode {
+        IssueNode {
+            title: "t".into(),
+            url: format!("https://example/{created}"),
+            state: state.into(),
+            created_at: created.into(),
+            closed_at: closed.map(str::to_string),
+            labels: labels.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    fn pr(state: &str, created: &str, merged: Option<&str>, closed: Option<&str>) -> PullNode {
+        PullNode {
+            title: "p".into(),
+            url: format!("https://example/pr/{created}"),
+            state: state.into(),
+            created_at: created.into(),
+            closed_at: closed.map(str::to_string),
+            merged_at: merged.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn split_milestone_em_dash() {
+        assert_eq!(
+            split_milestone("M0 — Foundation"),
+            ("M0".into(), "Foundation".into())
+        );
+    }
+
+    #[test]
+    fn split_milestone_no_dash() {
+        assert_eq!(
+            split_milestone("backlog"),
+            ("backlog".into(), String::new())
+        );
+    }
+
+    #[test]
+    fn stats_in_progress_ignores_project_items_prefers_label() {
+        // Agents flip the label; the Projects v2 Status field is a human
+        // board view that is not always in sync. Per AGENTS.md §6.1 the
+        // label is authoritative. Even when project_items claim "In
+        // Progress", we must fall back to label counts.
+        let f = Fetched {
+            issues: vec![
+                issue("OPEN", "2026-04-01T00:00:00Z", None, &[]),
+                issue("OPEN", "2026-04-02T00:00:00Z", None, &[]),
+            ],
+            pulls: vec![],
+            milestones: vec![],
+            project_items: Some(vec![
+                ProjectItemNode {
+                    status: Some("In Progress".into()),
+                },
+                ProjectItemNode {
+                    status: Some("In Progress".into()),
+                },
+            ]),
+        };
+        let s = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        assert_eq!(s.stats.in_progress, 0);
+    }
+
+    #[test]
+    fn stats_in_progress_counts_labelled_open_issues() {
+        let f = Fetched {
+            issues: vec![
+                issue(
+                    "OPEN",
+                    "2026-04-01T00:00:00Z",
+                    None,
+                    &["status:in-progress"],
+                ),
+                issue("OPEN", "2026-04-02T00:00:00Z", None, &[]),
+                issue(
+                    "CLOSED",
+                    "2026-04-03T00:00:00Z",
+                    Some("2026-04-10T00:00:00Z"),
+                    &["status:in-progress"],
+                ),
+            ],
+            pulls: vec![],
+            milestones: vec![],
+            project_items: None,
+        };
+        let s = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        assert_eq!(s.stats.in_progress, 1);
+    }
+
+    #[test]
+    fn done_last_30d_counts_issues_and_merged_prs_only() {
+        let f = Fetched {
+            issues: vec![
+                issue(
+                    "CLOSED",
+                    "2026-03-01T00:00:00Z",
+                    Some("2026-04-10T00:00:00Z"),
+                    &[],
+                ),
+                issue(
+                    "CLOSED",
+                    "2026-01-01T00:00:00Z",
+                    Some("2026-02-01T00:00:00Z"),
+                    &[],
+                ),
+            ],
+            pulls: vec![
+                pr(
+                    "MERGED",
+                    "2026-04-01T00:00:00Z",
+                    Some("2026-04-15T00:00:00Z"),
+                    Some("2026-04-15T00:00:00Z"),
+                ),
+                pr(
+                    "CLOSED",
+                    "2026-04-01T00:00:00Z",
+                    None,
+                    Some("2026-04-15T00:00:00Z"),
+                ),
+            ],
+            milestones: vec![],
+            project_items: None,
+        };
+        let s = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        assert_eq!(s.stats.done_last_30d, 2);
+    }
+
+    #[test]
+    fn activity_sorted_desc_and_capped() {
+        let f = Fetched {
+            issues: (0..30)
+                .map(|n| {
+                    let d = format!("2026-04-{:02}T00:00:00Z", n + 1);
+                    issue("OPEN", &d, None, &[])
+                })
+                .collect(),
+            pulls: vec![],
+            milestones: vec![],
+            project_items: None,
+        };
+        let s = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        assert!(s.activity.len() <= ACTIVITY_CAP);
+        for pair in s.activity.windows(2) {
+            assert!(pair[0].at >= pair[1].at, "activity must sort desc by at");
+        }
+    }
+
+    #[test]
+    fn current_milestone_is_first_open() {
+        let f = Fetched {
+            issues: vec![],
+            pulls: vec![],
+            milestones: vec![
+                MilestoneNode {
+                    title: "M0 — Foundation".into(),
+                    state: "OPEN".into(),
+                    due_on: Some("2026-06-01T00:00:00Z".into()),
+                    open_issue_count: 3,
+                    closed_issue_count: 5,
+                },
+                MilestoneNode {
+                    title: "M1 — Launch".into(),
+                    state: "OPEN".into(),
+                    due_on: Some("2026-09-01T00:00:00Z".into()),
+                    open_issue_count: 10,
+                    closed_issue_count: 0,
+                },
+            ],
+            project_items: None,
+        };
+        let s = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        assert_eq!(s.stats.current_milestone, "M0");
+        assert_eq!(s.milestones.len(), 2);
+        assert_eq!(s.milestones[0].total, 8);
+    }
+
+    #[test]
+    fn output_is_stable_across_runs() {
+        let f = Fetched {
+            issues: vec![
+                issue("OPEN", "2026-04-10T00:00:00Z", None, &[]),
+                issue(
+                    "CLOSED",
+                    "2026-04-05T00:00:00Z",
+                    Some("2026-04-15T00:00:00Z"),
+                    &[],
+                ),
+            ],
+            pulls: vec![],
+            milestones: vec![],
+            project_items: None,
+        };
+        let a = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        let b = build_state(&f, "2026-04-20T00:00:00Z", "2026-03-21T00:00:00Z");
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
+}

--- a/xtask/src/dashboard/state.rs
+++ b/xtask/src/dashboard/state.rs
@@ -1,0 +1,42 @@
+//! Serde types for `dashboard/data/state.json`.
+//!
+//! The schema is the contract exposed to `dashboard/src/app.js`; keep
+//! field names synchronised with the JS consumer (camelCase via
+//! `#[serde(rename_all)]`).
+
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct State {
+    pub generated_at: String,
+    pub stats: Stats,
+    pub milestones: Vec<Milestone>,
+    pub activity: Vec<ActivityEvent>,
+}
+
+#[derive(Serialize, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Stats {
+    pub open_issues: u32,
+    pub in_progress: u32,
+    #[serde(rename = "doneLast30d")]
+    pub done_last_30d: u32,
+    pub current_milestone: String,
+}
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct Milestone {
+    pub name: String,
+    pub title: String,
+    pub done: u32,
+    pub total: u32,
+}
+
+#[derive(Serialize, Debug, PartialEq, Eq)]
+pub struct ActivityEvent {
+    pub at: String,
+    pub kind: String,
+    pub title: String,
+    pub url: String,
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,0 +1,5 @@
+//! Library entry — exposes dev-task modules so integration tests under
+//! `xtask/tests/` can exercise the pipeline directly. The `xtask` binary
+//! in `src/main.rs` is a thin CLI wrapper over these modules.
+
+pub mod dashboard;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,8 +3,11 @@
 //! Invoked through the `justfile` (`just snapshot-dashboard`, `just seed-issues`, …).
 //! Each subcommand is a first-class workflow that any contributor can reproduce locally.
 
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use xtask::dashboard;
 
 #[derive(Parser)]
 #[command(name = "xtask", about = "physa-db workspace dev tasks")]
@@ -16,7 +19,14 @@ struct Cli {
 #[derive(Subcommand)]
 enum Cmd {
     /// Regenerate `dashboard/data/state.json` from GitHub Issues + Projects v2.
-    SnapshotDashboard,
+    SnapshotDashboard {
+        /// Print the JSON to stdout instead of writing to disk.
+        #[arg(long)]
+        dry_run: bool,
+        /// Override the output path (default: `dashboard/data/state.json`).
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Create GitHub issues from `docs/seed-issues.md`.
     SeedIssues {
         /// If true, print what would be created without calling the API.
@@ -34,6 +44,7 @@ enum Cmd {
 
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
@@ -42,28 +53,14 @@ fn main() -> Result<()> {
 
     let cli = Cli::parse();
     match cli.cmd {
-        Cmd::SnapshotDashboard => snapshot_dashboard(),
+        Cmd::SnapshotDashboard { dry_run, out } => dashboard::run(&dashboard::Args {
+            dry_run,
+            output: out,
+        }),
         Cmd::SeedIssues { dry_run } => seed_issues(dry_run),
         Cmd::ResearchPrompt { codename } => research_prompt(&codename),
         Cmd::BenchReport => bench_report(),
     }
-}
-
-fn snapshot_dashboard() -> Result<()> {
-    // Placeholder. See issue "Implement `xtask snapshot-dashboard`" in docs/seed-issues.md.
-    tracing::warn!("snapshot-dashboard: not yet implemented — emits a placeholder state.json");
-    let placeholder = serde_json::json!({
-        "generatedAt": "1970-01-01T00:00:00Z",
-        "stats": { "openIssues": 0, "inProgress": 0, "doneLast30d": 0, "currentMilestone": "M0" },
-        "milestones": [],
-        "activity": []
-    });
-    std::fs::create_dir_all("dashboard/data")?;
-    std::fs::write(
-        "dashboard/data/state.json",
-        serde_json::to_string_pretty(&placeholder)?,
-    )?;
-    Ok(())
 }
 
 #[expect(

--- a/xtask/tests/fixtures/expected_state.json
+++ b/xtask/tests/fixtures/expected_state.json
@@ -1,0 +1,67 @@
+{
+  "generatedAt": "2026-04-20T00:00:00Z",
+  "stats": {
+    "openIssues": 2,
+    "inProgress": 1,
+    "doneLast30d": 2,
+    "currentMilestone": "M0"
+  },
+  "milestones": [
+    {
+      "name": "M0",
+      "title": "Foundation",
+      "done": 3,
+      "total": 5
+    },
+    {
+      "name": "M1",
+      "title": "Launch",
+      "done": 0,
+      "total": 10
+    }
+  ],
+  "activity": [
+    {
+      "at": "2026-04-18T00:00:00Z",
+      "kind": "pr.opened",
+      "title": "Open PR",
+      "url": "https://example.invalid/pr/8"
+    },
+    {
+      "at": "2026-04-15T00:00:00Z",
+      "kind": "issue.closed",
+      "title": "Task C",
+      "url": "https://example.invalid/issues/3"
+    },
+    {
+      "at": "2026-04-12T00:00:00Z",
+      "kind": "pr.merged",
+      "title": "Merged PR",
+      "url": "https://example.invalid/pr/7"
+    },
+    {
+      "at": "2026-04-10T00:00:00Z",
+      "kind": "issue.opened",
+      "title": "Task A",
+      "url": "https://example.invalid/issues/1"
+    },
+    {
+      "at": "2026-04-08T00:00:00Z",
+      "kind": "issue.opened",
+      "title": "Task B",
+      "url": "https://example.invalid/issues/2"
+    },
+    {
+      "at": "2026-04-05T00:00:00Z",
+      "kind": "pr.opened",
+      "title": "Merged PR",
+      "url": "https://example.invalid/pr/7"
+    },
+    {
+      "at": "2026-04-01T00:00:00Z",
+      "kind": "issue.opened",
+      "title": "Task C",
+      "url": "https://example.invalid/issues/3"
+    }
+  ]
+}

--- a/xtask/tests/fixtures/issues_p1.json
+++ b/xtask/tests/fixtures/issues_p1.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "repository": {
+      "issues": {
+        "pageInfo": { "hasNextPage": true, "endCursor": "CUR1" },
+        "nodes": [
+          {
+            "title": "Task A",
+            "url": "https://example.invalid/issues/1",
+            "state": "OPEN",
+            "createdAt": "2026-04-10T00:00:00Z",
+            "closedAt": null,
+            "labels": { "nodes": [{ "name": "status:in-progress" }] }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/xtask/tests/fixtures/issues_p2.json
+++ b/xtask/tests/fixtures/issues_p2.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "repository": {
+      "issues": {
+        "pageInfo": { "hasNextPage": false, "endCursor": null },
+        "nodes": [
+          {
+            "title": "Task B",
+            "url": "https://example.invalid/issues/2",
+            "state": "OPEN",
+            "createdAt": "2026-04-08T00:00:00Z",
+            "closedAt": null,
+            "labels": { "nodes": [] }
+          },
+          {
+            "title": "Task C",
+            "url": "https://example.invalid/issues/3",
+            "state": "CLOSED",
+            "createdAt": "2026-04-01T00:00:00Z",
+            "closedAt": "2026-04-15T00:00:00Z",
+            "labels": { "nodes": [] }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/xtask/tests/fixtures/milestones.json
+++ b/xtask/tests/fixtures/milestones.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "repository": {
+      "milestones": {
+        "nodes": [
+          {
+            "title": "M0 — Foundation",
+            "state": "OPEN",
+            "dueOn": "2026-06-01T00:00:00Z",
+            "openIssueCount": 2,
+            "closedIssueCount": 3
+          },
+          {
+            "title": "M1 — Launch",
+            "state": "OPEN",
+            "dueOn": "2026-09-01T00:00:00Z",
+            "openIssueCount": 10,
+            "closedIssueCount": 0
+          }
+        ]
+      }
+    }
+  }
+}

--- a/xtask/tests/fixtures/projects_p1.json
+++ b/xtask/tests/fixtures/projects_p1.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "repository": {
+      "projectsV2": {
+        "nodes": [
+          {
+            "number": 1,
+            "items": {
+              "pageInfo": { "hasNextPage": false, "endCursor": null },
+              "nodes": [
+                {
+                  "fieldValues": {
+                    "nodes": [
+                      {
+                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                        "name": "In Progress",
+                        "field": { "name": "Status" }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "fieldValues": {
+                    "nodes": [
+                      {
+                        "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                        "name": "Done",
+                        "field": { "name": "Status" }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/xtask/tests/fixtures/pulls_p1.json
+++ b/xtask/tests/fixtures/pulls_p1.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "repository": {
+      "pullRequests": {
+        "pageInfo": { "hasNextPage": false, "endCursor": null },
+        "nodes": [
+          {
+            "title": "Merged PR",
+            "url": "https://example.invalid/pr/7",
+            "state": "MERGED",
+            "createdAt": "2026-04-05T00:00:00Z",
+            "closedAt": "2026-04-12T00:00:00Z",
+            "mergedAt": "2026-04-12T00:00:00Z"
+          },
+          {
+            "title": "Open PR",
+            "url": "https://example.invalid/pr/8",
+            "state": "OPEN",
+            "createdAt": "2026-04-18T00:00:00Z",
+            "closedAt": null,
+            "mergedAt": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/xtask/tests/snapshot.rs
+++ b/xtask/tests/snapshot.rs
@@ -1,0 +1,77 @@
+//! Integration test: replays recorded GraphQL fixtures through the
+//! snapshot pipeline and asserts byte-for-byte equality against
+//! `expected_state.json`.
+//!
+//! The fixture files live under `tests/fixtures/`; regenerate
+//! `expected_state.json` with:
+//!
+//! ```bash
+//! UPDATE_FIXTURE=1 cargo test -p xtask --test snapshot
+//! ```
+//!
+//! This proves two things at once:
+//!
+//! - **Schema match** — output conforms to `dashboard/src/app.js`.
+//! - **Idempotency** — repeated runs over the same inputs produce the
+//!   same bytes (stable sort + injected clock).
+
+use std::path::PathBuf;
+
+use xtask::dashboard::{build_from, gh::FixtureFetcher};
+
+const NOW: &str = "2026-04-20T00:00:00Z";
+const CUTOFF_30D: &str = "2026-03-21T00:00:00Z";
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures"))
+}
+
+fn render() -> String {
+    let fetcher = FixtureFetcher::new(fixtures_dir());
+    let (state, _) = build_from(&fetcher, "owner", "repo", NOW, CUTOFF_30D)
+        .expect("fixture pipeline must not fail");
+    let mut s = serde_json::to_string_pretty(&state).expect("serialize");
+    s.push('\n');
+    s
+}
+
+#[test]
+fn replay_matches_expected_fixture() {
+    let actual = render();
+    let expected_path = fixtures_dir().join("expected_state.json");
+
+    if std::env::var("UPDATE_FIXTURE").is_ok() {
+        std::fs::write(&expected_path, &actual).expect("write fixture");
+        return;
+    }
+
+    let expected = std::fs::read_to_string(&expected_path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read {} ({e}); run with UPDATE_FIXTURE=1 to regenerate",
+            expected_path.display()
+        )
+    });
+    assert_eq!(actual, expected, "snapshot drift vs expected_state.json");
+}
+
+#[test]
+fn replay_is_idempotent() {
+    assert_eq!(render(), render(), "non-deterministic snapshot output");
+}
+
+#[test]
+fn paginates_issues_across_two_pages() {
+    let actual = render();
+    assert!(
+        actual.contains("Task A"),
+        "first page (issues_p1) must contribute"
+    );
+    assert!(
+        actual.contains("Task B"),
+        "second page (issues_p2) must contribute"
+    );
+    assert!(
+        actual.contains("Task C"),
+        "second page (issues_p2) must contribute"
+    );
+}


### PR DESCRIPTION
Replaces the placeholder stub in `xtask snapshot-dashboard` with a
working GraphQL-backed generator for `dashboard/data/state.json`.

Pipeline (in `xtask/src/dashboard/`):

- `gh.rs`: `GraphQLFetcher` trait with two impls — `GhCli` shells out
  to `gh api graphql --input -` (zero new HTTP/auth deps), and
  `FixtureFetcher` reads pre-recorded JSON so tests never touch the
  network. `resolve_repo` picks owner/name from `gh repo view` with
  `PHYSA_SNAPSHOT_OWNER` / `PHYSA_SNAPSHOT_REPO` env overrides for CI.
- `fetch.rs`: narrow GraphQL queries for issues, pull requests,
  milestones, and Projects v2 items — cursor-based pagination per
  dataset. Asks for exactly the fields the state.json schema needs.
- `snapshot.rs`: pure synthesis of the `State` struct. Stable sort on
  milestones (by name) and activity (desc by `at`, tiebroken by kind
  and url). Activity capped at 50 events. `now`/`cutoff` are injected
  so tests and CI runs are reproducible byte-for-byte.
- `state.rs`: serde types mirroring `dashboard/src/app.js`
  (camelCase via `rename_all`; `doneLast30d` pinned explicitly).

In-progress count: uses the `status:in-progress` label as the truth
source per AGENTS.md §6.1 (agents flip labels on claim; Projects v2
Status is a human board view). Projects v2 items are still pulled
(honoring the issue's AC) and observed in debug logs.

CLI: new `--dry-run` (prints to stdout) and `--out <path>` flags.
`PHYSA_SNAPSHOT_NOW` env var pins `generatedAt` for reproducibility.
Tracing writes to stderr so `--dry-run | jq .` works cleanly.

Workflow (`.github/workflows/snapshot-dashboard.yml`): inline bash
placeholder replaced by `cargo run --release -p xtask --
snapshot-dashboard`, gated by `dtolnay/rust-toolchain@stable` and a
Swatinem cache. Triggers remain `workflow_dispatch` only (per the
existing comment: re-enable when GitHub Pages is turned on).

Tests: 8 unit tests in `snapshot.rs` cover stats edge cases, milestone
splitting, activity ordering, and byte-stability across runs.
`tests/snapshot.rs` is a replay-mode integration test backed by
`tests/fixtures/*.json`. Regenerate the expected fixture with
`UPDATE_FIXTURE=1 cargo test -p xtask --test snapshot`.

Closes #2

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
