### PR TITLE
chore(skills): sync remote in /next + optimization research in /plan-feature

### DIFF
--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -36,6 +36,36 @@ the GitHub API ensures two agents can never both believe they own the
 same issue — the loser sees the winner's assignee on re-fetch and
 abandons.
 
+## Step 0 — Sync with the remote
+
+Before anything else, refresh every remote-tracking ref. On a
+multi-dev / multi-agent project the local view goes stale fast
+(branches pushed by others, new `agent/*` branches, advanced `main`),
+and every later check — existing claims, candidate branches, FF-pull
+of main — must read fresh data. A `/next` run on a stale clone can
+silently branch off an out-of-date `main` and ship a broken diff.
+
+```bash
+git fetch --all --prune --tags
+```
+
+Then verify local `main` is not diverged from `origin/main`. If
+local main carries commits that origin doesn't, something was
+committed directly to main and not pushed — that's a human issue, not
+ours to paper over:
+
+```bash
+LOCAL_AHEAD="$(git rev-list --count origin/main..main 2>/dev/null || echo 0)"
+if [[ "$LOCAL_AHEAD" -gt 0 ]]; then
+  echo "main has $LOCAL_AHEAD local-only commits not on origin — investigate before /next"
+  exit 1
+fi
+```
+
+If this fails, stop and report. Never claim an issue on top of a
+divergent local `main` — the branch you create will carry commits
+that do not belong to the issue.
+
 ## Step 1 — Pre-flight sanity checks
 
 ```bash
@@ -196,7 +226,16 @@ Look for:
 
 ## Step 7 — Start work
 
-Now, and only now, begin the actual implementation. Use:
+Before writing code, confirm the issue body carries an
+**Optimization research brief** (the section produced by
+`/plan-feature` step 3b). If it is missing — common on older issues
+or on tasks filed before that step existed — produce a short one
+inline *before* touching code. One hour of web/rustdoc/SOTA scanning
+now is the cheapest insurance against a compound-interest refactor
+later. If the issue is trivial plumbing (docs, CI, renames), a
+one-line "no optimisation surface" note is enough.
+
+Then, and only then, begin the actual implementation. Use:
 
 - `/run-stress <scenario>` for any storage / MVCC / cluster change.
 - `/run-bench <mode>` if the issue is labelled `type:perf`.

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -61,7 +61,9 @@ If the feature is commercial-pillar (FM-001..099), cite the relevant promise
 in [`docs/requirements/positioning.md`](../../../docs/requirements/positioning.md)
 §1 or an incumbent-compat need.
 
-## Step 3 — First-principles derivation (`AGENTS.md` §11)
+## Step 3 — First-principles derivation + optimization hunt (`AGENTS.md` §11)
+
+### 3a. Constraints and theoretical optimum
 
 In 5–15 lines, answer:
 
@@ -77,6 +79,59 @@ In 5–15 lines, answer:
 If you find yourself writing "because Neo4j does it" or "because Postgres
 uses X", STOP. That's analogy thinking (`AGENTS.md` §11). Rewrite from the
 constraint.
+
+### 3b. Hunt for the maximal-optimization path
+
+Before locking the implementation, actively scan for a better approach
+than the first one that came to mind. At project start the cost of
+picking a wrong primitive compounds faster than any other decision: an
+hour of research now is worth weeks of refactor later. This is not
+optional for features on hot paths or with durability/consistency
+implications.
+
+Scan, in this order:
+
+- **Papers & SOTA benchmarks.** Web-search the problem class (e.g.
+  "lock-free hash map rust 2025", "MVCC GC amortisation", "HNSW vs
+  DiskANN recall/QPS"). Prefer recent arXiv preprints, conference
+  talks (VLDB, SIGMOD, NSDI, ATC), and engineering blogs with real
+  numbers. Cite what you find.
+- **Rust ecosystem sweep.** For every candidate primitive, check
+  [docs.rs](https://docs.rs) and [lib.rs](https://lib.rs): existing
+  production-grade crates, their benchmark claims, last-release date,
+  licence (Apache-2.0 / MIT compatible — no GPL-family), maintenance
+  status. A neglected crate with theoretical wins is a trap; a
+  well-maintained crate with a 95 %-perfect fit saves months.
+- **Rust stdlib & nightly.** Check whether the feature is better
+  handled by a soon-stabilising API (`core::simd` portable SIMD,
+  `allocator_api`, `strict_provenance`, `BufRead::read_until`).
+  Cite the tracking issue; choose based on the stabilisation ETA
+  versus our milestone.
+- **Hardware floor.** If this is a hot path, compute the theoretical
+  lower bound on the target hardware (NVMe seq read ~7 GB/s, DRAM
+  random ~100 ns, L1 ~4 cycles, AVX-512 width, etc.). A design that
+  leaves 10× on the table is not an optimisation — it's a ceiling.
+
+Produce a **research brief** (include it verbatim in the issue body):
+
+```
+### Optimization research brief
+
+Candidates evaluated:
+  1. <name> — <claim / cite> — picked / rejected: <reason>
+  2. <name> — <claim / cite> — picked / rejected: <reason>
+  ...
+
+Picked: <N> because <reason grounded in §3a optimum>.
+Rejected: <others with 1-line reason each>.
+Uncovered surprise: <a finding the naïve plan missed, or "none">.
+Hardware floor estimate: <lower bound> — our target: <value> (gap: <ratio>).
+```
+
+The brief is the receipts: future contributors must be able to see
+why the non-obvious choice won. If this step produces nothing
+surprising, say so explicitly — "obvious pick confirmed after sweep"
+is a valid outcome, but skipping the sweep is not.
 
 ## Step 4 — Acceptance criteria
 
@@ -136,6 +191,10 @@ Commercial | W-X (+ brief citation)
 
 ### First-principles derivation
 [5–15 lines]
+
+### Optimization research brief
+[candidates evaluated, pick, rejections with reasons, uncovered
+surprise or "none", hardware floor vs target]
 
 ### Acceptance criteria
 - [ ] ...

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -97,7 +97,7 @@ Scan, in this order:
   talks (VLDB, SIGMOD, NSDI, ATC), and engineering blogs with real
   numbers. Cite what you find.
 - **Rust ecosystem sweep.** For every candidate primitive, check
-  [docs.rs](https://docs.rs) and [lib.rs](https://lib.rs): existing
+  `docs.rs` and `lib.rs` (the index-of-crates sites): existing
   production-grade crates, their benchmark claims, last-release date,
   licence (Apache-2.0 / MIT compatible — no GPL-family), maintenance
   status. A neglected crate with theoretical wins is a trap; a


### PR DESCRIPTION
## Summary
- \`/next\` Step 0: \`git fetch --all --prune --tags\` + abort if local \`main\` has commits \`origin/main\` doesn't. Closes the multi-dev / multi-agent stale-clone window.
- \`/plan-feature\` Step 3 split into **3a** (first-principles, unchanged) and **3b** (maximal-optimization hunt — web/SOTA, docs.rs + lib.rs sweep, Rust stdlib/nightly, hardware floor). Produces a research brief embedded in the issue body.
- \`/next\` Step 7: require the brief to exist before coding; produce inline if the issue predates the rule.

## Why
At project start, picking a wrong primitive compounds faster than any other decision. One hour of SOTA + rustdoc scanning is the cheapest insurance against a compound-interest refactor. Pairs with the existing first-principles rule (AGENTS.md §11, §15).

## Test plan
- [ ] Dry-run \`/next\` on a stale clone — Step 0 aborts cleanly if local main diverges.
- [ ] Invoke \`/plan-feature\` on a new FM row — output template now carries the \`Optimization research brief\` section.
- [ ] Existing \`/next\` on an in-progress issue still resumes (no regression on Step 2 early-return path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)