### PR TITLE
fix(ci): point CI badge to mroche14/physa-db (unblocks lychee)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/dynovant/physa-db/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/dynovant/physa-db/ci.yml?branch=main&label=CI&style=flat-square"></a>
+  <a href="https://github.com/mroche14/physa-db/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/mroche14/physa-db/ci.yml?branch=main&label=CI&style=flat-square"></a>
   <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square">
   <img alt="Rust" src="https://img.shields.io/badge/rust-2024-orange?style=flat-square">
   <img alt="Status" src="https://img.shields.io/badge/status-pre--alpha-lightgrey?style=flat-square">


### PR DESCRIPTION
## Summary
- README line 11 pointed the CI badge href + shields.io image at \`dynovant/physa-db\`. Repo lives at \`mroche14/physa-db\`, so lychee gets a 404 and the \`docs-links\` job fails on \`main\` and blocks every downstream PR.
- Flip both occurrences to \`mroche14/physa-db\`.

## Test plan
- [ ] \`docs-links\` job passes on this PR.
- [ ] \`main\` CI goes green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)