### PR TITLE
fix(readme): make assets readable in GitHub dark + light modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img src="assets/logo.svg" alt="physa-db" width="320">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.svg">
+    <img src="assets/logo.svg" alt="physa-db" width="320">
+  </picture>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/dynovant/physa-db/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/dynovant/physa-db/ci.yml?branch=main&label=CI&style=flat-square"></a>
+  <a href="https://github.com/mroche14/physa-db/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/mroche14/physa-db/ci.yml?branch=main&label=CI&style=flat-square"></a>
   <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square">
   <img alt="Rust" src="https://img.shields.io/badge/rust-2024-orange?style=flat-square">
   <img alt="Status" src="https://img.shields.io/badge/status-pre--alpha-lightgrey?style=flat-square">

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" width="1000" height="620" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-label="physa-db architecture: five horizontal layers with a Rust core bar">
+  <rect x="0" y="0" width="1000" height="620" rx="12" fill="#F7F2E8"/>
   <rect x="70" y="30" width="40" height="500" rx="6" fill="#C77F3E"/>
   <text x="90" y="280" transform="rotate(-90 90 280)" text-anchor="middle" font-size="14" font-weight="800" letter-spacing="4" fill="#ffffff">RUST CORE</text>
 

--- a/assets/logo-dark.svg
+++ b/assets/logo-dark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 80" width="360" height="80" role="img" aria-label="physa-db logo">
+  <g transform="translate(6, 8) scale(0.64)">
+    <line x1="30" y1="72" x2="70" y2="72" stroke="#F4E4CF" stroke-width="3" stroke-linecap="round"/>
+    <line x1="30" y1="72" x2="50" y2="26" stroke="#F4E4CF" stroke-width="3" stroke-linecap="round"/>
+    <line x1="50" y1="26" x2="70" y2="72" stroke="#F4E4CF" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="50" cy="26" r="9" fill="#C77F3E" stroke="#F4E4CF" stroke-width="2"/>
+    <circle cx="30" cy="72" r="9" fill="#F4E4CF"/>
+    <circle cx="70" cy="72" r="9" fill="#F4E4CF"/>
+  </g>
+  <text x="82" y="55" font-family="system-ui, -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="44" font-weight="800" fill="#F4E4CF" letter-spacing="-1.2">physa<tspan fill="#C77F3E">-db</tspan></text>
+</svg>

--- a/assets/query.svg
+++ b/assets/query.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 500" width="1000" height="500" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-label="physa-db hybrid query plan: graph traversal, vector similarity, and BM25 converge into a single query plan">
+  <rect x="0" y="0" width="1000" height="500" rx="12" fill="#F7F2E8"/>
   <g>
     <rect x="40" y="60" width="220" height="100" rx="8" fill="#ffffff" stroke="#C77F3E" stroke-width="2"/>
     <text x="50" y="85" font-size="13" font-weight="800" letter-spacing="1" fill="#C77F3E">GRAPH TRAVERSAL</text>

--- a/assets/symbol-dark.svg
+++ b/assets/symbol-dark.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="physa-db brand symbol: a triangular three-node graph">
+  <line x1="30" y1="72" x2="70" y2="72" stroke="#F4E4CF" stroke-width="3" stroke-linecap="round"/>
+  <line x1="30" y1="72" x2="50" y2="26" stroke="#F4E4CF" stroke-width="3" stroke-linecap="round"/>
+  <line x1="50" y1="26" x2="70" y2="72" stroke="#F4E4CF" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="50" cy="26" r="9" fill="#C77F3E" stroke="#F4E4CF" stroke-width="2"/>
+  <circle cx="30" cy="72" r="9" fill="#F4E4CF"/>
+  <circle cx="70" cy="72" r="9" fill="#F4E4CF"/>
+</svg>


### PR DESCRIPTION
## Summary

On main, the README hero SVGs had three dark-mode readability bugs:

1. **`logo.svg`** — indigo (`#0B0D2E`) text + nodes on a **transparent** canvas. On GitHub dark mode (`#0d1117`), the logo was nearly invisible.
2. **`architecture.svg`** — internal boxes are white (fine), but the vertical **connecting arrows** between them live on the transparent canvas with indigo strokes → invisible on dark.
3. **`query.svg`** — same pattern: the fan-in lines + the arrow to "Ranked results" drawn on the transparent outer area in indigo → invisible on dark.

Hero JPGs, shields.io badges, and the mermaid block were already dark/light-safe.

## Fix — two strategies, one per asset class

- **Logo** (should feel "native," no card frame): add `assets/logo-dark.svg` (ivory `#F4E4CF` on transparent) and switch the README to `<picture>` with `prefers-color-scheme: dark`. GitHub's markdown renderer honors this in both light and dark themes.
- **Diagrams** (can carry a frame): add an ivory (`#F7F2E8`, `rx=12`) full-canvas background rect as the first child of each SVG. Inner white cards now sit on top of an ivory "page," giving a subtle two-tone depth that reads as intentional on any theme.

Also adds `symbol-dark.svg` (kept in sync with `symbol.svg`) for future favicon / social preview work.

## Palette rationale

- Ivory background `#F7F2E8` is softer than pure white — less harsh, less "medical PDF," still brand-family.
- Ivory text/strokes `#F4E4CF` (from the existing palette) on dark matches the copper+ivory+indigo brand system and keeps contrast WCAG-AA-clean on `#0d1117`.

## Test plan

- [ ] View README on GitHub with light theme: logo = dark ink, diagrams = ivory card with white inner boxes
- [ ] Toggle to dark theme: logo flips to ivory, diagrams stay readable (inner boxes stay white on ivory)
- [ ] Confirm `<picture>` srcset logic works in GitHub's markdown renderer
- [ ] No regressions in hero JPG rendering, mermaid block, or badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)