### PR TITLE
feat(skills): /next owns its PR through the first CI round

### DIFF
--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -246,19 +246,112 @@ Then, and only then, begin the actual implementation. Use:
 `Closes #N` on the final commit that the PR will merge. This feeds the
 reaper's freshness check and the dashboard activity stream.
 
-## Step 8 — Exit
+## Step 8 — Open the PR
 
 When the work is ready for review:
 
 ```bash
-gh issue edit "$N" --add-label status:needs-review --remove-label status:in-progress
 gh pr create --fill --base main
+PR_NUM="$(gh pr view --json number --jq '.number')"
 ```
 
-The `status:needs-review` label releases the claim automatically (the
-reaper will not touch a `needs-review` issue). If you need to abandon
-the work without a PR, invoke `/abandon <ready|blocked> <reason>` — do
-not just walk away.
+Do **not** flip the issue label yet. The claim still belongs to this
+agent until Step 9 confirms the PR is green — otherwise a red PR
+becomes a stale `needs-review` that the reaper will not touch and no
+other agent will pick up.
+
+## Step 9 — Watch the PR through CI
+
+A PR is not "done" when pushed — it is done when every required check
+passes. An agent that opens a PR and walks away ships the red to the
+human reviewer. The agent owns its PR until CI is green.
+
+### 9a — Block on the first round
+
+```bash
+gh pr checks "$PR_NUM" --watch --fail-fast --interval 10
+CHECK_RC=$?
+```
+
+`--watch` blocks while any check is pending. `--fail-fast` returns
+non-zero the moment one fails (no need to wait for the rest). The
+`--interval 10` polls every 10 s — costs nothing on a quiet repo, and
+is polite on GitHub's API.
+
+### 9b — If all green
+
+```bash
+if [[ "$CHECK_RC" -eq 0 ]]; then
+  gh issue edit "$N" \
+    --add-label status:needs-review \
+    --remove-label status:in-progress
+  echo "PR #$PR_NUM green — handed off for review"
+  exit 0
+fi
+```
+
+### 9c — If any red: diagnose, fix, re-push
+
+Budget: **3 fix iterations**. Past that, the failure is almost
+certainly not a surface bug — it needs a human.
+
+```bash
+ITER=0
+while [[ "$CHECK_RC" -ne 0 && "$ITER" -lt 3 ]]; do
+  ITER=$((ITER + 1))
+  echo "=== CI fix iteration $ITER/3 ==="
+
+  # Which checks failed, and why.
+  FAILED_JOBS="$(gh pr checks "$PR_NUM" --json name,state,link \
+    --jq '[.[] | select(.state == "FAILURE" or .state == "CANCELLED")]')"
+  echo "$FAILED_JOBS"
+
+  # Fetch logs for each failed job. The `--log-failed` flag returns only
+  # failing steps, which fits agent context windows better than full logs.
+  RUN_ID="$(gh pr checks "$PR_NUM" --json link \
+    --jq '.[] | select(.state == "FAILURE") | .link' \
+    | head -1 | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')"
+  gh run view "$RUN_ID" --log-failed > /tmp/failed-${PR_NUM}-${ITER}.log
+
+  # Read the log, reason about the root cause, apply the fix,
+  # run `/pre-commit-check`, commit with a `fix(ci): …` prefix, push.
+  # THEN re-enter the watch loop:
+  gh pr checks "$PR_NUM" --watch --fail-fast --interval 10
+  CHECK_RC=$?
+done
+```
+
+### 9d — If still red after 3 iterations
+
+The failure is not mechanical. Hand the PR back to a human instead of
+wasting more cycles:
+
+```bash
+gh pr comment "$PR_NUM" --body "CI failing after 3 automated fix \
+attempts. Handing to human — see \`/tmp/failed-${PR_NUM}-*.log\` \
+snapshots in the last commits. Likely root cause: <one-sentence \
+summary from the logs>."
+gh issue edit "$N" \
+  --add-label agent:needs-human \
+  --remove-label status:in-progress
+```
+
+Do **not** mark the issue `status:needs-review` while CI is red — a
+red PR masquerading as ready-to-review poisons the review queue and
+demoralises the human reviewer who opens it expecting a clean diff.
+
+### 9e — If the tree is clean but checks are stuck pending
+
+GitHub Actions sometimes wedges (queue stall, runner outage). After 30
+minutes of pending with no state transition:
+
+```bash
+gh pr comment "$PR_NUM" --body "CI stuck in pending for 30+ min — \
+re-running via \`gh pr rerun\`."
+gh run rerun "$RUN_ID" --failed
+```
+
+If the rerun also stalls, treat as 9d and escalate.
 
 ## What NOT to do
 
@@ -277,3 +370,9 @@ not just walk away.
   Move to the next candidate; the winner will finish or release.
 - Do not claim issues across repositories. `/next` operates in the
   current repo only.
+- Do not mark an issue `status:needs-review` while its PR has a red
+  check. The label is a promise to the human reviewer; a red PR
+  breaks it. Step 9 exists so this never happens.
+- Do not walk away from a PR you opened. Own it through the first CI
+  round; if you cannot stay, call `/abandon` with a clear hand-off
+  comment on the PR so the next agent (or human) knows the state.


### PR DESCRIPTION
## Motivation

An agent using \`/next\` currently opens a PR and walks away. If CI fails, the PR sits red until a human — or a downstream agent — notices and fixes. That's exactly what happened on PR #23: a broken \`dynovant/physa-db\` URL (from the brand-system commit) shipped through because lychee only runs in CI, and the opening agent wasn't watching.

Two approaches close this gap:

- **Catch-early** (pre-commit mirror of CI) — cheap when you run it, but relies on discipline.
- **Catch-after** (skill watches its own PR) — autonomous, catches it even when someone forgets the first layer.

This PR implements the second. The two compound.

## What's in

Step 8 (Open the PR) and Step 9 (Watch the PR through CI) replace the old single Step 8:

- **Step 8** — \`gh pr create\` only. Does **not** flip the claim label yet.
- **Step 9a** — \`gh pr checks --watch --fail-fast --interval 10\`. Blocks on server-side streaming (not polling).
- **Step 9b** — all green → flip to \`status:needs-review\`, exit.
- **Step 9c** — any red → fetch \`--log-failed\`, reason, fix, push, re-watch. Budget: **3 iterations**.
- **Step 9d** — still red after 3 → \`agent:needs-human\` with one-sentence root-cause on the PR. Never mark \`needs-review\` over red.
- **Step 9e** — stuck-pending > 30 min → \`gh run rerun --failed\`, escalate if that also stalls.

Two new \"What NOT to do\" entries lock the rules:

- Never mark \`status:needs-review\` while CI is red.
- Never walk away from a PR you opened.

## Design choices worth noting

- **\`--watch\` + \`--fail-fast\`** instead of a sleep-polling loop. \`gh\` uses GitHub's server-side state-transition stream, so it's instantaneous and polite on the API.
- **Budget of 3 fix iterations**, mirroring Step 4's race-retry budget. Same discipline: bounded retries → explicit escalation, never infinite loops.
- **Label timing** — the \`status:needs-review\` flip moved from Step 8 to Step 9b. This is the key invariant: the label is a promise to the reviewer, and a red PR breaks it.

## Test plan

- [ ] Dry-read pass of the skill by a fresh agent: the flow is unambiguous
- [ ] A later /next run on a failing PR actually triggers 9c and pushes a fix
- [ ] The 3-iteration cap triggers 9d and labels the issue \`agent:needs-human\`
- [ ] No regression in existing Steps 0–7

🤖 Generated with [Claude Code](https://claude.com/claude-code)