### PR TITLE
Codify canonical issue labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,159 @@
+{
+  "labels": [
+    {
+      "name": "area:ai-native",
+      "color": "5319e7",
+      "description": "AI-agent-native features (vector, RAG, KG)"
+    },
+    {
+      "name": "area:benchmark",
+      "color": "9ecbff",
+      "description": "Benchmarks, perf tracking"
+    },
+    {
+      "name": "area:client",
+      "color": "539bf5",
+      "description": "Client libraries, SDKs"
+    },
+    {
+      "name": "area:cluster",
+      "color": "1f6feb",
+      "description": "Cluster, replication, sharding"
+    },
+    {
+      "name": "area:docs",
+      "color": "79b8ff",
+      "description": "Documentation, ADRs, examples"
+    },
+    {
+      "name": "area:dx",
+      "color": "bfdbf7",
+      "description": "Developer experience, tooling, skills"
+    },
+    {
+      "name": "area:infra",
+      "color": "c0d3eb",
+      "description": "Infrastructure, CI/CD"
+    },
+    {
+      "name": "area:query",
+      "color": "0366d6",
+      "description": "Query parser, planner, executor"
+    },
+    {
+      "name": "area:research",
+      "color": "6f42c1",
+      "description": "Research, competitor analysis"
+    },
+    {
+      "name": "area:server",
+      "color": "2188ff",
+      "description": "Server binary, protocols (Bolt, HTTP, MCP)"
+    },
+    {
+      "name": "area:storage",
+      "color": "0052cc",
+      "description": "Storage engine, WAL, codec, recovery"
+    },
+    {
+      "name": "type:adr",
+      "color": "5319e7",
+      "description": "Architecture Decision Record"
+    },
+    {
+      "name": "type:bug",
+      "color": "d73a4a",
+      "description": "Bug fix"
+    },
+    {
+      "name": "type:docs",
+      "color": "0075ca",
+      "description": "Documentation only"
+    },
+    {
+      "name": "type:feature",
+      "color": "0e8a16",
+      "description": "New feature"
+    },
+    {
+      "name": "type:perf",
+      "color": "fbca04",
+      "description": "Performance improvement (bench evidence)"
+    },
+    {
+      "name": "type:refactor",
+      "color": "c5def5",
+      "description": "Refactor, no behavior change"
+    },
+    {
+      "name": "type:research",
+      "color": "bfd4f2",
+      "description": "Investigation, spike"
+    },
+    {
+      "name": "type:stress",
+      "color": "e99695",
+      "description": "Stress / chaos / soak test"
+    },
+    {
+      "name": "status:blocked",
+      "color": "d73a4a",
+      "description": "Blocked by external dependency"
+    },
+    {
+      "name": "status:done",
+      "color": "cccccc",
+      "description": "Merged / resolved"
+    },
+    {
+      "name": "status:in-progress",
+      "color": "fbca04",
+      "description": "Claimed - see claim-marker comment"
+    },
+    {
+      "name": "status:needs-review",
+      "color": "1d76db",
+      "description": "PR open, awaiting review"
+    },
+    {
+      "name": "status:ready",
+      "color": "0e8a16",
+      "description": "Ready to pick up via /next"
+    },
+    {
+      "name": "priority:p0",
+      "color": "b60205",
+      "description": "Drop everything"
+    },
+    {
+      "name": "priority:p1",
+      "color": "d93f0b",
+      "description": "High priority"
+    },
+    {
+      "name": "priority:p2",
+      "color": "fbca04",
+      "description": "Normal priority"
+    },
+    {
+      "name": "priority:p3",
+      "color": "cccccc",
+      "description": "Nice to have"
+    },
+    {
+      "name": "agent:good-first-task",
+      "color": "7057ff",
+      "description": "Good for a newly-onboarded agent"
+    },
+    {
+      "name": "agent:long-running",
+      "color": "008672",
+      "description": "Task > 1 day of effort"
+    },
+    {
+      "name": "agent:needs-human",
+      "color": "e99695",
+      "description": "Requires human judgement - no auto-claim"
+    }
+  ]
+}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,49 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: sync-labels
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reconcile declared labels
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          count="$(jq '.labels | length' .github/labels.yml)"
+          if [[ "$count" -ne 31 ]]; then
+            echo "Expected 31 labels in .github/labels.yml, found $count" >&2
+            exit 1
+          fi
+
+          jq -c '.labels[]' .github/labels.yml | while read -r label; do
+            name="$(jq -r '.name' <<<"$label")"
+            color="$(jq -r '.color' <<<"$label")"
+            description="$(jq -r '.description' <<<"$label")"
+
+            echo "Reconciling $name"
+            gh label create "$name" \
+              --color "$color" \
+              --description "$description" \
+              --force
+          done
+
+          echo "Declared labels reconciled. Stray labels are intentionally left untouched."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,13 +141,17 @@ Every CI gate is a local `just` command — **if it passes locally, it must pass
 
 ### Labels (canonical set)
 
-| Prefix | Examples | Meaning |
+| Prefix | Canonical labels | Meaning |
 |--------|----------|---------|
-| `area:` | `area:storage`, `area:query`, `area:cluster`, `area:server`, `area:client`, `area:docs`, `area:benchmark`, `area:infra`, `area:dx` | Subsystem |
-| `type:` | `type:feature`, `type:bug`, `type:perf`, `type:refactor`, `type:research`, `type:docs`, `type:stress` | Nature of work |
+| `area:` | `area:storage`, `area:query`, `area:cluster`, `area:server`, `area:client`, `area:docs`, `area:benchmark`, `area:infra`, `area:dx`, `area:research`, `area:ai-native` | Subsystem |
+| `type:` | `type:feature`, `type:bug`, `type:perf`, `type:refactor`, `type:research`, `type:docs`, `type:stress`, `type:adr` | Nature of work |
 | `status:` | `status:ready`, `status:in-progress`, `status:blocked`, `status:needs-review`, `status:done` | Lifecycle |
 | `priority:` | `p0`, `p1`, `p2`, `p3` | Urgency |
 | `agent:` | `agent:good-first-task`, `agent:needs-human`, `agent:long-running` | Agent-specific hints |
+
+The source of truth for label metadata is [`.github/labels.yml`](./.github/labels.yml).
+The `sync-labels` workflow creates missing labels and updates declared labels
+on `main`; it does not delete stray labels automatically.
 
 ### Issue template
 Every issue must have:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ See [`AGENTS.md`](./AGENTS.md) for the full agent contract — engineering-disci
 
 Public development dashboard — features in flight, benchmarks, open issues — at a GitHub Pages URL *(pending first deploy)*.
 
+## Project labels
+
+Issue labels are declared in [`.github/labels.yml`](./.github/labels.yml) and reconciled by the `sync-labels` workflow on `main`. The workflow creates missing labels and updates declared metadata, but it never deletes stray labels automatically.
+
+To propose a new label, open a PR that updates both [`.github/labels.yml`](./.github/labels.yml) and the canonical table in [`AGENTS.md`](./AGENTS.md) §6. Include the prefix, color, description, and why the existing taxonomy cannot express the work.
+
 ## Quick links
 
 - [`docs/requirements/positioning.md`](./docs/requirements/positioning.md) — commercial pillar (§1) + AI-agent-native technical pillar (§§2–7)


### PR DESCRIPTION
## What

Adds a declared label manifest and a GitHub Actions workflow that reconciles repository labels from that manifest.

## Why

Refs #3. The canonical label set was created imperatively during bootstrap; this makes label metadata reproducible and recoverable.

## How

- Added .github/labels.yml with the 31 canonical labels, colors, and descriptions.
- Added sync-labels, which runs on main pushes, daily schedule, and manual dispatch.
- The workflow uses gh label create --force so declared labels are created or updated idempotently while stray labels are intentionally left untouched.
- Updated AGENTS.md §6 and README.md so label changes have a documented proposal path.

## Benchmarks

N/A — infrastructure metadata only.

## Stress

N/A — no storage, MVCC, cluster, or concurrency behavior changed.

## Checklist

- [x] .github/labels.yml contains 31 declared labels
- [x] Sync workflow runs on push to main and daily schedule
- [x] Stray labels are not deleted by the workflow
- [x] README documents how to propose new labels
- [x] Local CI passed: mise exec -- just ci