### PR TITLE
chore(skills): research rigor — recency + exhaustive docs across planning

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -94,6 +94,20 @@ just stress <scenario>
 just bench-compare main
 ```
 
+### Optimization research brief
+
+<Exhaustive per `plan-feature §3b` — research window, every URL
+consulted (including dead-ends and "not applicable" reads), search
+queries with engines + date filters, candidate libs with current
+`crates.io` versions at plan date, SOTA method with year + citation +
+disposition (adopt / adapt / reject), dead-ends explored, picked /
+rejected with reasons, hardware floor vs target. Sources ≤ 12 months
+old unless justified. Paste the brief from the planning step verbatim.>
+
+<If this issue is trivial plumbing (docs, CI, renames, asset bumps,
+label-only changes): write **"no optimisation surface"** on a single
+line and move on.>
+
 ### Out of scope
 
 <What this issue is NOT doing. Protect the scope against creep.>
@@ -114,6 +128,8 @@ just bench-compare main
 - [ ] Title is imperative, ≤ 72 chars.
 - [ ] Labels: area, type, status, priority, agent.
 - [ ] FM row cited (or "not applicable — explain").
+- [ ] Optimization research brief present and exhaustive (or explicit
+      "no optimisation surface" for trivial plumbing).
 - [ ] No competitor names.
 - [ ] No reference to `private/` paths or files.
 ```

--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -229,11 +229,21 @@ Look for:
 Before writing code, confirm the issue body carries an
 **Optimization research brief** (the section produced by
 `/plan-feature` step 3b). If it is missing — common on older issues
-or on tasks filed before that step existed — produce a short one
-inline *before* touching code. One hour of web/rustdoc/SOTA scanning
-now is the cheapest insurance against a compound-interest refactor
-later. If the issue is trivial plumbing (docs, CI, renames), a
-one-line "no optimisation surface" note is enough.
+or on tasks filed before that step existed — produce one inline
+*before* touching code. One hour of web/rustdoc/SOTA scanning now is
+the cheapest insurance against a compound-interest refactor later. If
+the issue is trivial plumbing (docs, CI, renames), a one-line "no
+optimisation surface" note is enough.
+
+The inline brief must meet the same bar as `plan-feature §3b`:
+≤ 12 months recency on sources, crate versions at their current
+`crates.io` values, **every URL consulted logged exhaustively** (not
+only those cited — dead-ends and "not applicable" reads too), search
+queries + engines + date filters recorded, SOTA method named with
+year + citation + disposition (adopt / adapt / reject), hardware
+floor vs target. A brief that is three bullets is not a brief —
+produce the full exhaustive form or `/abandon blocked
+"under-specified: requires plan-feature with exhaustive research brief"`.
 
 Then, and only then, begin the actual implementation. Use:
 

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -89,24 +89,54 @@ hour of research now is worth weeks of refactor later. This is not
 optional for features on hot paths or with durability/consistency
 implications.
 
+**Recency window (non-negotiable).** Sources must be ≤ 12 months old
+unless you can justify an older one inline (e.g. a seminal paper whose
+successors have not improved on it). Use date-filtered searches (arXiv
+`submittedDate` ≥ today − 12 months; Google `tbs=qdr:y`; GitHub
+`pushed:>YYYY-MM-DD`). For every library/crate, record the **latest
+stable version on `crates.io` at the date of this plan** — not the
+version pinned in our `Cargo.toml` six months ago. Stale inputs
+silently cap the design.
+
+**Exhaustive documentation (non-negotiable).** The research is only
+valuable if it is reproducible. The brief below records, without
+abbreviation:
+
+- every URL visited, including dead-ends and "not applicable" reads —
+  closing the search perimeter is how the next agent avoids re-doing
+  your work;
+- every search query + the engine/tool it ran on + the date filter
+  applied;
+- for every candidate library / crate / API, the exact version string
+  (`crate A.B.C` as of `crates.io` YYYY-MM-DD, Rust edition, compiler
+  channel, nightly tracking-issue URL) at the consult date;
+- for the SOTA method of the problem class, the method name +
+  publication year + citation URL, and physa-db's disposition
+  (**adopt / adapt / reject**) with a one-line reason.
+
+Silent sweeps are not sweeps. If you cannot list what you read, the
+work is not done — reviewers will reject a brief that hides its search.
+
 Scan, in this order:
 
 - **Papers & SOTA benchmarks.** Web-search the problem class (e.g.
-  "lock-free hash map rust 2025", "MVCC GC amortisation", "HNSW vs
+  "lock-free hash map rust 2026", "MVCC GC amortisation", "HNSW vs
   DiskANN recall/QPS"). Prefer recent arXiv preprints, conference
-  talks (VLDB, SIGMOD, NSDI, ATC), and engineering blogs with real
-  numbers. Cite what you find.
+  talks (VLDB, SIGMOD, NSDI, ATC, OSDI, EuroSys), and engineering
+  blogs with real numbers. Name the SOTA method explicitly — not "a
+  hash map", but "Abseil SwissTable (2018) + follow-ups through 2025".
 - **Rust ecosystem sweep.** For every candidate primitive, check
   `docs.rs` and `lib.rs` (the index-of-crates sites): existing
-  production-grade crates, their benchmark claims, last-release date,
-  licence (Apache-2.0 / MIT compatible — no GPL-family), maintenance
-  status. A neglected crate with theoretical wins is a trap; a
-  well-maintained crate with a 95 %-perfect fit saves months.
+  production-grade crates, their benchmark claims, **current latest
+  version on `crates.io`**, last-release date, licence (Apache-2.0 /
+  MIT compatible — no GPL-family), maintenance status. A neglected
+  crate with theoretical wins is a trap; a well-maintained crate with
+  a 95 %-perfect fit saves months.
 - **Rust stdlib & nightly.** Check whether the feature is better
   handled by a soon-stabilising API (`core::simd` portable SIMD,
-  `allocator_api`, `strict_provenance`, `BufRead::read_until`).
-  Cite the tracking issue; choose based on the stabilisation ETA
-  versus our milestone.
+  `allocator_api`, `strict_provenance`, `BufRead::read_until`). Cite
+  the tracking issue; choose based on the stabilisation ETA versus
+  our milestone.
 - **Hardware floor.** If this is a hot path, compute the theoretical
   lower bound on the target hardware (NVMe seq read ~7 GB/s, DRAM
   random ~100 ns, L1 ~4 cycles, AVX-512 width, etc.). A design that
@@ -117,21 +147,38 @@ Produce a **research brief** (include it verbatim in the issue body):
 ```
 ### Optimization research brief
 
-Candidates evaluated:
-  1. <name> — <claim / cite> — picked / rejected: <reason>
-  2. <name> — <claim / cite> — picked / rejected: <reason>
-  ...
+**Research window:** YYYY-MM-DD – YYYY-MM-DD (≤ 12 months unless justified).
 
-Picked: <N> because <reason grounded in §3a optimum>.
-Rejected: <others with 1-line reason each>.
-Uncovered surprise: <a finding the naïve plan missed, or "none">.
-Hardware floor estimate: <lower bound> — our target: <value> (gap: <ratio>).
+**Sources consulted (exhaustive — every URL visited, including dead-ends and "not applicable" reads):**
+  - <URL> — <title> — <date read> — <finding / "not applicable">
+  - <URL> — ...
+
+**Search queries used:**
+  - "<query>" on <engine/site> (date filter: last 12 months)
+  - ...
+
+**Candidates evaluated:**
+  1. <crate/lib name> <version X.Y.Z> (crates.io, YYYY-MM-DD) — <claim / cite> — picked / rejected: <reason>
+  2. ...
+
+**SOTA method for this problem class:** <method name>, <year>, <citation URL>. physa-db disposition: **adopt / adapt / reject** — <reason>.
+
+**Picked:** <N> because <reason grounded in §3a optimum>.
+
+**Rejected:** <others with 1-line reason each>.
+
+**Dead-ends explored:** <paths that looked promising but weren't> — why.
+
+**Uncovered surprise:** <finding the naïve plan missed, or "none">.
+
+**Hardware floor estimate:** <lower bound> — our target: <value> (gap: <ratio>).
 ```
 
 The brief is the receipts: future contributors must be able to see
-why the non-obvious choice won. If this step produces nothing
-surprising, say so explicitly — "obvious pick confirmed after sweep"
-is a valid outcome, but skipping the sweep is not.
+why the non-obvious choice won **and retrace the full search**. If
+this step produces nothing surprising, say so explicitly — "obvious
+pick confirmed after exhaustive sweep" is a valid outcome; skipping
+the sweep is not, and an abbreviated sweep is not a sweep.
 
 ## Step 4 — Acceptance criteria
 

--- a/.claude/skills/research-competitor/SKILL.md
+++ b/.claude/skills/research-competitor/SKILL.md
@@ -65,6 +65,10 @@ Partial coverage produces partial conclusions. For each competitor, **every** so
 - **Independent benchmarks** — third-party perf reports. Weight independent > vendor-authored.
 - **Implementation patterns** — the **engineering choice** for each feature (data structures, wire protocols, consensus algorithms, GC strategies, concrete file formats), not just the feature name.
 
+**Version discipline.** Consult every source at the **current stable / main branch** (for code) or the **latest published release line** (for docs / blogs / benchmarks). Pin the exact commit SHA, tag, or release date in the profile's References section — a two-year-old fork exposes a different feature surface. Stale reads produce stale conclusions.
+
+**Documentation trail (exhaustive).** The References section of the private profile lists **every URL consulted**, not only those cited in the body — including dead-ends and "not applicable" reads. For each entry: URL, title, date read, one-line finding. Silent reads are not reads; the next agent must be able to retrace the full search perimeter without re-doing it.
+
 Coverage gaps are surfaced in the private file's "Open questions" section and filed as `type:research` issues — never silently omitted.
 
 ## Step 2 — Write the PRIVATE profile

--- a/.claude/skills/write-adr/SKILL.md
+++ b/.claude/skills/write-adr/SKILL.md
@@ -94,6 +94,21 @@ novel to physa-db.}}
 {{Brief: for each rejected alternative, which constraint it violates
 or which overhead it forces.}}
 
+## Optimization research brief (`AGENTS.md` §11)
+
+{{Paste the exhaustive brief from `plan-feature §3b`: research window,
+**sources consulted (every URL, including dead-ends and "not
+applicable" reads)**, search queries + engines + date filters,
+candidates with version strings (`crate A.B.C` as of `crates.io`
+YYYY-MM-DD), SOTA method (name + year + citation + disposition
+adopt/adapt/reject), dead-ends explored, uncovered surprises,
+hardware floor vs target. All sources ≤ 12 months old unless an older
+source is justified inline.}}
+
+An ADR without this brief is a decision made without receipts. The
+reviewer must be able to retrace the full search, not only read the
+conclusion. An abbreviated brief is a rejected brief.
+
 ## Consequences
 
 **Positive**
@@ -129,6 +144,10 @@ Before opening the PR, verify:
 - [ ] `Features addressed` header lists at least one real `FM-NNN` row.
 - [ ] First-principles derivation contains **numbers** (bytes, μs, RTTs),
       not only prose.
+- [ ] "Optimization research brief" section present, exhaustive (every
+      URL consulted incl. dead-ends, queries with date filters, crate
+      versions from `crates.io`, SOTA method with year + disposition),
+      and all sources ≤ 12 months old (older sources justified inline).
 - [ ] At least one alternative is rejected with a constraint-based
       argument (not "it's uglier").
 - [ ] No competitor is named in public text. Use codenames or generic


### PR DESCRIPTION
## Summary

Codifies, across `plan-feature` / `write-adr` / `file-issue` / `next` / `research-competitor`:

- **Recency window (≤ 12 months)** with explicit date-filtered searches: arXiv `submittedDate`, Google `tbs=qdr:y`, GitHub `pushed:>`. Older sources must be justified inline.
- **Crate version discipline**: every candidate lib pinned to its current `crates.io` version at plan date, not the `Cargo.toml` pin from months ago.
- **SOTA method naming**: publication year + citation URL + physa-db disposition (`adopt` / `adapt` / `reject`) is mandatory — not "a hash map", but "Abseil SwissTable (2018) + follow-ups through 2025".
- **Exhaustive documentation** of the search — the headline rule: every URL visited (dead-ends and "not applicable" reads included), every search query with engine + date filter, every dead-end explored. Silent sweeps are explicitly rejected as non-sweeps.
- **`write-adr`** gains a required "Optimization research brief" section + checklist item mirroring `plan-feature §3b`.
- **`file-issue`** template carries the brief slot, with explicit `"no optimisation surface"` fallback for trivial plumbing.
- **`next §7`** raises the bar for inline rattrapage briefs: same recency + exhaustiveness as `plan-feature §3b`, else `/abandon blocked`.
- **`research-competitor`** Step 1 adds version discipline (stable branch / latest release line, pin SHA/tag/date) and documentation trail (every URL in References, not only those cited).

## Why

Previous state: `plan-feature §3b` already mandated a SOTA sweep, but (a) recency wasn't operationalised — an agent could cite 2023 papers in 2026 and pass review; (b) the research log was summary-only, so a reviewer couldn't retrace the search and dead-ends disappeared; (c) `write-adr` / `file-issue` didn't inherit the same bar, so issues filed outside `plan-feature` lost the signal.

Founder direction (2026-04-21): "les etudes doivent exhaustivement etre documentees" — the research is only valuable if it is reproducible. The receipts matter as much as the conclusion.

## Test plan

- [ ] Next `/plan-feature` invocation produces a brief with all new fields (research window, exhaustive URL list, queries with date filters, versioned candidates, SOTA method with year + disposition).
- [ ] Next `/write-adr` produces an ADR with the "Optimization research brief" section populated.
- [ ] Next `/file-issue` (outside `/plan-feature`) uses the new template slot.
- [ ] Next `/next §7` rattrapage either meets the new bar or triggers `/abandon blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)