### PR TITLE
docs: de-attribute requirements and fix AFM mappings

### DIFF
--- a/docs/requirements/ai-agent-workloads.md
+++ b/docs/requirements/ai-agent-workloads.md
@@ -182,7 +182,7 @@ We group AI-agent workloads into six families. Any agentic system in production 
 
 ### Protocols
 
-- Bolt v5 (Neo4j driver compatibility).
+- Bolt v5 for migration-friendly driver compatibility.
 - HTTP/JSON query endpoint.
 - gRPC with reflection.
 - **MCP (Model Context Protocol) server** so agents can treat physa-db as a tool directly.

--- a/docs/requirements/feature-matrix-aggregate.md
+++ b/docs/requirements/feature-matrix-aggregate.md
@@ -4,32 +4,55 @@
 
 | AFM-NNN | Feature | Category | Seen in N | Typical implementation | Disposition |
 |---------|---------|----------|-----------|------------------------|-------------|
-| AFM-001 | Native property graph storage | Storage | 1 | Linked-list record format on disk, page-cache dependent | redesign |
-| AFM-002 | Declarative pattern-matching language | Query | 2 | Logical plan to volcano/pipelined execution | adopt |
-| AFM-003 | Raft-based metadata and read replicas | Cluster | 1 | Raft for primaries, async replication for reads | adopt |
-| AFM-004 | Vector similarity search index | Query | 1 | Embedded HNSW in memory / Lucene | redesign |
-| AFM-005 | Fine-grained RBAC | Tenancy | 1 | Enforced at query planning level | adopt |
-| AFM-006 | Distributed Massively Parallel Processing (MPP) | Cluster | 1 | Custom distributed C++ engine | adopt |
-| AFM-007 | Compiled Query Language | Query | 1 | Compiled down to C++ | redesign |
-| AFM-008 | High-velocity Bulk Ingest | Ops | 1 | Distributed loading into memory structures | redesign |
-| AFM-009 | Aggressive Data Compression | Storage | 1 | 2x-10x compression | adopt |
-| AFM-010 | In-Memory C++ Engine | Storage | 1 | In-memory structures with snapshot isolation | redesign |
-| AFM-011 | Analytical Storage Mode | Storage | 1 | Drops transaction guarantees for raw speed | non-goal |
-| AFM-012 | Streaming First Integration | Ops | 1 | Deep integrations with Kafka/Pulsar | adopt |
-| AFM-013 | Decoupled Compute and Storage | Cluster | 1 | Stateless query nodes, stateful storage nodes | redesign |
-| AFM-014 | Generic KV-Store Backend | Storage | 1 | LSM-tree (RocksDB) | non-goal |
-| AFM-015 | Hard Memory Tracker Aborts | Ops | 1 | Aborts queries when hitting memory high watermark | non-goal |
-| AFM-016 | Proprietary Query Language | Query | 3 | Custom language alongside standards | non-goal |
-| AFM-017 | Native Multi-Model Storage | Storage | 1 | Handles documents, graphs, and KV in one engine | non-goal |
-| AFM-018 | Embedded JavaScript Microservices | Ops | 1 | V8 engine runs within the DB process | non-goal |
-| AFM-019 | Native GraphQL Interface | Query | 1 | Parses GraphQL directly to internal query plans | non-goal |
-| AFM-020 | Sparse Matrix Algebra Backend | Query | 1 | GraphBLAS matrix multiplication traversals | non-goal |
-| AFM-021 | In-Memory Dual-Representation Storage | Storage | 1 | Optimized in-memory structures | redesign |
-| AFM-022 | Sub-millisecond Cold Starts | Ops | 1 | Fast startup for serverless | adopt |
-| AFM-023 | Zero-ETL Virtualization Layer | Storage | 1 | Translates graph queries to remote SQL/Data Lakes | non-goal |
-| AFM-024 | Vectorized In-Memory Compute | Query | 1 | Apache Arrow based execution | adopt |
-| AFM-025 | Local Storage Cache | Storage | 1 | Caches remote data locally | redesign |
-| AFM-026 | Worst-Case Optimal Joins (WCOJ) | Query | 1 | Leapfrog triejoin variants | adopt |
-| AFM-027 | Factorized Execution | Query | 1 | Compressed intermediate query representations | adopt |
-| AFM-028 | Embedded Columnar Graph Engine | Storage | 1 | DuckDB-style embedded OLAP graph | adopt |
-| AFM-029 | Pure OLAP-only Focus | Ops | 1 | Sacrifices OLTP for pure OLAP speed | non-goal |
+| AFM-001 | Native property-graph storage | Storage | 2 | Custom graph-native store optimized for adjacency-local reads | adopt |
+| AFM-002 | In-memory-first graph storage | Storage | 1 | RAM-resident graph structures with durability layered underneath | redesign |
+| AFM-003 | Embedded / library deployment mode | DX | 1 | Linkable database library with local file-backed state | adopt |
+| AFM-004 | Generic KV-backed graph storage | Storage | 3 | Graph entities encoded over an LSM or KV engine | non-goal |
+| AFM-005 | Sparse-matrix / GraphBLAS graph representation | Query | 1 | Adjacency stored and queried as sparse matrices and algebraic expressions | non-goal |
+| AFM-006 | Columnar analytical graph storage | Storage | 1 | Disk-backed columnar property storage with CSR-style adjacency | adopt |
+| AFM-007 | Native multi-model document+graph+KV engine | Storage | 1 | Single engine spans document, graph, and key-value workloads | non-goal |
+| AFM-008 | Zero-ETL graph virtualization | Storage | 1 | Query graph structure over external systems without importing data | non-goal |
+| AFM-009 | Local cache over external data | Storage | 1 | Materialize or cache remote graph-shaped data close to execution | non-goal |
+| AFM-010 | WAL + snapshot durability | Storage | 2 | Persist mutations through a write-ahead log plus periodic durable checkpoints | adopt |
+| AFM-011 | Consensus-backed cluster coordination | Cluster | 4 | Replicated cluster state with leader election and durable quorum updates | adopt |
+| AFM-012 | Read-scale secondaries / replicas | Cluster | 1 | Route read workloads to non-writer replicas or secondaries | adopt |
+| AFM-013 | Shared-nothing MPP query execution | Query | 1 | Move graph computation across cluster workers instead of centralizing it | redesign |
+| AFM-014 | Separated compute and storage | Cluster | 2 | Independent query and storage tiers with networked data access | redesign |
+| AFM-015 | ACID transactions | Storage | 6 | Transactional reads and writes with durable commit semantics | adopt |
+| AFM-017 | Fine-grained RBAC | Tenancy | 4 | Privileges scoped to databases, labels, operations, or objects | adopt |
+| AFM-018 | Logical multi-tenancy / namespaces / multi-database | Tenancy | 6 | Separate databases or namespaces within one cluster or process | adopt |
+| AFM-019 | SSO / LDAP / enterprise authentication | Tenancy | 1 | External identity providers and centralized auth integration | adopt |
+| AFM-020 | openCypher compatibility | Query | 6 | Cypher parser, planner, and runtime compatibility for migration ease | adopt |
+| AFM-021 | GQL support | Query | 1 | Native ISO GQL surface or credible rollout toward it | adopt |
+| AFM-022 | Proprietary graph query language | Query | 3 | Vendor-specific graph DSL or language extensions as primary surface | non-goal |
+| AFM-023 | GraphQL-native API surface | Query | 1 | Database directly exposes GraphQL schema and operations | non-goal |
+| AFM-024 | Vector similarity index | Query | 5 | Built-in ANN structure such as HNSW for embedding retrieval | adopt |
+| AFM-025 | Hybrid graph + vector query composition | Query | 4 | Compose ANN retrieval with graph expansion and filtering in one plan | adopt |
+| AFM-026 | Full-text search | Query | 5 | Integrated text index and ranking inside the database query surface | adopt |
+| AFM-027 | Geospatial search | Query | 3 | Native geo types or geo indexes in graph-aware queries | adopt |
+| AFM-028 | Graph algorithms library | Query | 6 | Built-in or tightly coupled algorithm suite over stored graphs | adopt |
+| AFM-029 | Streaming ingest / CDC connectors | Ops | 2 | Native ingestion from message buses or change streams | adopt |
+| AFM-030 | High-speed bulk import | Ops | 5 | Dedicated large-scale loader separate from transactional writes | adopt |
+| AFM-031 | Backup / restore / disaster recovery | Ops | 3 | Operational tooling for snapshot, restore, and recovery workflows | adopt |
+| AFM-032 | Managed cloud service | Ops | 4 | Vendor-operated hosted deployment path | adopt |
+| AFM-033 | Operator / cloud-native cluster control plane | Ops | 3 | Kubernetes operator or comparable cluster automation surface | adopt |
+| AFM-034 | Schema-flexible start / optional schema enforcement | Storage | 2 | Allow writes before full schema lock-in, then layer stronger checks | redesign |
+| AFM-035 | Strongly typed / schema-driven storage layout | Storage | 1 | Physical encoding depends directly on declared schema metadata | redesign |
+| AFM-036 | Custom procedures / UDF / module system | Query | 1 | Extend query execution with user-defined native or scripted code | adopt |
+| AFM-037 | Query compilation / generated code | Query | 1 | Compile query logic into generated or native code paths | adopt |
+| AFM-038 | Factorized execution | Query | 1 | Compressed intermediate/result representations reduce blow-up | adopt |
+| AFM-039 | Worst-case-optimal / novel join algorithms | Query | 1 | Join engine optimized beyond traditional binary join trees | adopt |
+| AFM-040 | Vectorized / pipeline-parallel analytical execution | Query | 1 | Pipelines, morsels, and vectorized operators for analytical scans | adopt |
+| AFM-041 | Hard memory-abort guardrails | Ops | 1 | Protect process stability by aborting work at memory thresholds | non-goal |
+| AFM-043 | Embedded application runtime inside DB | Ops | 1 | Run user application code inside the database process | non-goal |
+| AFM-044 | Native vector / embedding value type | Query | 2 | First-class typed embedding values instead of raw numeric lists | adopt |
+| AFM-045 | AI / agent integration surface | Tooling | 2 | Schema introspection, MCP endpoints, or agent-facing database tools | adopt |
+| AFM-047 | Workload-isolated analytical workspaces | Cluster | 1 | Separate read-write and read-only or analytic execution surfaces | redesign |
+| AFM-048 | Pricing or licence gating of production features | Packaging | 3 | Clustering, security, or ops limited to paid editions | non-goal |
+| AFM-049 | Browser / visual studio / schema designer tooling | Tooling | 5 | Integrated GUI for querying, modeling, and exploration | adopt |
+| AFM-050 | Permissive OSS licensing | Packaging | 3 | Apache/MIT-style licensing for production use and redistribution | adopt |
+| AFM-051 | Restrictive source-available / fair-code licensing | Packaging | 4 | SSPL, BSL, non-commercial, or similar restrictions | non-goal |
+| AFM-053 | Arrow-native / columnar in-memory compute | Query | 1 | Execution layer leans on Arrow-style columnar batches | redesign |
+| AFM-054 | Redis-module / protocol adjacency | Packaging | 1 | Graph engine runs as a module or adjacent surface over Redis | non-goal |
+| AFM-055 | Gremlin compatibility | Query | 1 | Support Gremlin as an additional graph query language | non-goal |
+| AFM-056 | Graph over external SQL / lakehouse tables | Storage | 1 | Map graph abstractions onto existing SQL or lakehouse tables | non-goal |

--- a/docs/requirements/feature-matrix.md
+++ b/docs/requirements/feature-matrix.md
@@ -16,7 +16,7 @@ Each row links to the governing ADR (if any), the tracking issue (once filed), a
 | ID | Area | Feature | Kind | Tier | ADR | Issue |
 |----|------|---------|------|------|-----|-------|
 | FM-001 | query | GQL (ISO/IEC 39075:2024) support | Parity | M3 | ADR-0002 | — |
-| FM-002 | query | openCypher compatibility (AFM-002) | Parity | M3 | ADR-0002 | — |
+| FM-002 | query | openCypher compatibility (AFM-020) | Parity | M3 | ADR-0002 | — |
 | FM-003 | server | Bolt v5 wire protocol | Parity | M4 | — | — |
 | FM-004 | server | HTTP/JSON query endpoint | Parity | M4 | — | — |
 | FM-005 | storage | ACID transactions with MVCC snapshot isolation | Parity | M3 | ADR-0004 | — |
@@ -35,14 +35,14 @@ Each row links to the governing ADR (if any), the tracking issue (once filed), a
 | FM-018 | query | Subgraph / snapshot materialisation | Novel | M8 | — | — |
 | FM-019 | query | Compiled query plans (JIT via `cranelift` or AoT codegen) | Novel | M6 | — | — |
 | FM-020 | query | Vectorised execution for analytical workloads | Novel | M6 | — | — |
-| FM-021 | cluster | Raft-based metadata consensus (AFM-003) | Parity | M5 | ADR-0005 | — |
+| FM-021 | cluster | Raft-based metadata consensus (AFM-011) | Parity | M5 | ADR-0005 | — |
 | FM-022 | cluster | Transparent horizontal scaling | Parity | M5 | ADR-0005 | — |
 | FM-023 | cluster | Online re-sharding with zero downtime | Novel | M5 | ADR-0005 | — |
 | FM-024 | cluster | Multi-region async replication | Parity | M6 | — | — |
 | FM-025 | cluster | Cross-region strong-consistency option | Stretch | M7 | — | — |
 | FM-026 | tenancy | Native multi-tenancy with namespaces | Parity | M5 | — | — |
 | FM-027 | tenancy | Per-tenant resource quotas | Parity | M5 | — | — |
-| FM-028 | tenancy | Per-tenant RBAC (AFM-005) | Parity | M5 | — | — |
+| FM-028 | tenancy | Per-tenant RBAC (AFM-017) | Parity | M5 | — | — |
 | FM-029 | tenancy | Per-tenant backup schedules | Parity | M5 | — | — |
 | FM-030 | ops | Slow-query log with plan explanation | Parity | M4 | — | — |
 | FM-031 | ops | Structured, queryable audit log | Parity | M5 | — | — |
@@ -53,7 +53,7 @@ Each row links to the governing ADR (if any), the tracking issue (once filed), a
 | FM-036 | ecosystem | Migration tool from dominant competitor dump format | Parity | M7 | — | — |
 | FM-037 | ecosystem | Kubernetes operator | Parity | M7 | — | — |
 | FM-038 | ecosystem | Terraform provider | Parity | M7 | — | — |
-| FM-039 | dx | Embedded mode (library usage, no server) (AFM-028) | Parity | M3 | — | — |
+| FM-039 | dx | Embedded mode (library usage, no server) (AFM-003) | Parity | M3 | — | — |
 | FM-040 | dx | Reproducible benchmark suite public to users | Novel | M6 | — | — |
 | FM-041 | ops | Zero-tuning auto-configured memory management | Novel | M4 | — | — |
 | FM-042 | ops | Graceful disk spill for memory pressure (no hard aborts) | Novel | M4 | — | — |
@@ -66,7 +66,7 @@ Every row below cites the workload family (from [`ai-agent-workloads.md`](./ai-a
 |----|------|---------|------|------|-----|-------|----------|
 | FM-100 | ai-native | `VECTOR<F16/F32, DIM>` first-class property type | Novel | M3 | — | — | W-A, W-B, W-D |
 | FM-101 | ai-native | `SPARSE_VECTOR` first-class property type (SPLADE-style) | Novel | M6 | — | — | W-B |
-| FM-102 | ai-native | HNSW index for dense vectors (AFM-004) | Parity | M3 | — | — | W-A, W-B, W-D |
+| FM-102 | ai-native | HNSW index for dense vectors (AFM-024) | Parity | M3 | — | — | W-A, W-B, W-D |
 | FM-103 | ai-native | IVF-PQ index for memory-efficient ANN at scale | Novel | M6 | — | — | W-B, W-D |
 | FM-104 | ai-native | Similarity operators: `COSINE`, `DOT`, `L2`, `HAMMING`, `JACCARD` | Parity | M3 | — | — | W-A, W-B |
 | FM-105 | ai-native | Retrieval operators: `NEAREST(v, K)`, `WITHIN_DISTANCE(v, r)` | Parity | M3 | — | — | W-B |
@@ -87,7 +87,7 @@ Every row below cites the workload family (from [`ai-agent-workloads.md`](./ai-a
 | FM-120 | ai-native | Token-budget-aware result shaping (`CONTEXT_WINDOW(results, budget)`) | Novel | M4 | — | — | W-B |
 | FM-121 | ai-native | `TO_JSONLD(node)` and Markdown summary output shaping | Novel | M4 | — | — | W-B, W-C |
 | FM-122 | ai-native | MCP (Model Context Protocol) server — agents call physa-db as a tool directly | Novel | M4 | — | — | W-A, W-B, W-C, W-D, W-E |
-| FM-123 | ai-native | High-throughput streaming ingest (AFM-008, AFM-012) (target 100k events/s per tenant on reference HW) | Novel | M4 | — | — | W-E |
+| FM-123 | ai-native | High-throughput streaming ingest (AFM-029) (target 100k events/s per tenant on reference HW) | Novel | M4 | — | — | W-E |
 | FM-124 | ai-native | Time-partitioned storage layout with cold-tier auto-demotion | Novel | M6 | — | — | W-E |
 | FM-125 | ai-native | JSON-LD property type for structured log payloads | Novel | M4 | — | — | W-E |
 | FM-126 | ai-native | Per-tenant vector isolation (one tenant's vectors never in another's index) | Parity | M5 | — | — | W-A, W-B |
@@ -99,5 +99,3 @@ Every row below cites the workload family (from [`ai-agent-workloads.md`](./ai-a
 _Add rows as research surfaces new requirements. Row IDs are stable once published — do not renumber._
 
 _Tier column is the target milestone. Tiers may shift once M1 locks the feature set and M2 promotes the architecture ADRs — rows do not get renumbered, only re-tiered with a changelog entry._
- a changelog entry._
- changelog entry._

--- a/docs/requirements/feature-matrix.md
+++ b/docs/requirements/feature-matrix.md
@@ -57,6 +57,8 @@ Each row links to the governing ADR (if any), the tracking issue (once filed), a
 | FM-040 | dx | Reproducible benchmark suite public to users | Novel | M6 | — | — |
 | FM-041 | ops | Zero-tuning auto-configured memory management | Novel | M4 | — | — |
 | FM-042 | ops | Graceful disk spill for memory pressure (no hard aborts) | Novel | M4 | — | — |
+| FM-043 | tenancy | External auth providers: SSO / LDAP / OIDC / SAML (AFM-019) | Parity | M5 | — | — |
+| FM-044 | ops | Fully managed cloud service (AFM-032) | Parity | M7 | — | — |
 
 ## AI-agent-native rows (FM-100…)
 

--- a/docs/requirements/non-goals.md
+++ b/docs/requirements/non-goals.md
@@ -34,7 +34,7 @@ We target **mixed transactional + small-to-medium analytical workloads** (LDBC S
 
 **Why:** OLAP warehouses have a different cost model (columnar on object store with large fan-out); merging those is a distraction.
 
-## Not a pure-analytical in-memory engine (AFM-011, AFM-029)
+## Not a pure-analytical in-memory engine
 
 physa-db will not offer an "analytical mode" that disables ACID guarantees, logging, and crash recovery just to fit graphs into memory and run ingest faster. We guarantee durability and consistency. We also refuse a pure OLAP-only architecture that sacrifices high-frequency transactional point-updates (OLTP), as AI agent memory requires both.
 
@@ -78,43 +78,43 @@ Pure Rust. This is an inviolable technology choice, not an engineering preferenc
 
 We implement GQL (FM-001) because the standard aligns with our design and unlocks portability. If the ISO spec evolves in ways that harm users, we extend rather than regress — via the `PHYSA` extension namespace clearly documented and shared between both dialects.
 
-## Not a generic KV-store backend (AFM-014)
+## Not a generic KV-store backend (AFM-004)
 
 physa-db uses a graph-native columnar adjacency layout. We do not layer our graph engine on top of a generic KV-store (like RocksDB or FoundationDB).
 
 **Why:** Relational or KV-stores mapped to graphs are suboptimal for index-free adjacency and deep traversals, introducing unnecessary I/O overhead.
 
-## Not a system that relies on hard memory aborts (AFM-015)
+## Not a system that relies on hard memory aborts (AFM-041)
 
 We do not use blunt memory trackers that abort queries simply because the process nears a limit.
 
 **Why:** Aborting queries is a poor user experience. The engine must gracefully spill to NVMe or use memory-mapped structures to maintain stability under memory pressure.
 
-## Not a proprietary query language ecosystem (AFM-016)
+## Not a proprietary query language ecosystem (AFM-022)
 
 We natively support standard query languages: GQL and openCypher. We will not invent a new, proprietary query language.
 
 **Why:** Standard languages reduce the learning curve, prevent vendor lock-in, and provide a seamless migration path from legacy systems.
 
-## Not an application server / embedded JS runner (AFM-018)
+## Not an application server / embedded JS runner (AFM-043)
 
 physa-db will not embed V8 or any JavaScript/WASM runtime to run user-provided microservices inside the database process.
 
 **Why:** Running application logic inside the storage engine causes unpredictable virtual memory bloat, compromises database stability, and introduces unnecessary security vulnerabilities. Compute and application logic belong in the application tier.
 
-## Not a native GraphQL backend (AFM-019)
+## Not a native GraphQL backend (AFM-023)
 
 We will not parse GraphQL natively into internal query plans as our primary interface.
 
 **Why:** GraphQL is a powerful API layer but an inflexible database query language, lacking the necessary constructs for deep, recursive graph traversals or advanced analytics. Users should use standard GQL/openCypher, and layer GraphQL servers on top if needed.
 
-## Not a matrix-math execution engine (AFM-020)
+## Not a matrix-math execution engine (AFM-005)
 
 physa-db uses graph-native pointer/adjacency-based traversals, rather than translating queries into sparse matrix multiplications (GraphBLAS).
 
 **Why:** Matrix math limits performance for simple point-queries and CRUD operations. While fast for complex analytics, it introduces unnecessary overhead for the mixed transactional workloads that AI agents require.
 
-## Not a "Zero-ETL" virtualization layer (AFM-023)
+## Not a "Zero-ETL" virtualization layer (AFM-008, AFM-056)
 
 We are a primary database. We do not virtualize graph queries over existing external SQL databases or data lakes (like Iceberg or Snowflake) without importing the data.
 

--- a/docs/requirements/performance-targets.md
+++ b/docs/requirements/performance-targets.md
@@ -58,4 +58,3 @@ All numbers are:
 1. Median of ≥ 10 runs after warm-up.
 2. Produced by `just bench-macro` and checked in under `docs/benchmarks/results/YYYY-MM-DD-*.md`.
 3. Reproducible from commit SHA on the reference hardware.
-ardware.

--- a/docs/requirements/positioning.md
+++ b/docs/requirements/positioning.md
@@ -12,13 +12,13 @@ It is a property graph engine whose primary workloads are those produced by agen
 
 The founder's immutable vision (held privately) captured the **commercial** motivation: end the incumbent's pricing era so SaaS builders can use a graph DB as freely as Postgres. That remains true.
 
-This file captures the **technical** target established on 2026-04-20: AI-agent workloads drive the feature set. Existing graph databases (Neo4j, Memgraph, Dgraph, TigerGraph, etc.) were designed in the pre-agent era; their storage layouts, query planners, and data types predate the workloads AI agents actually produce. We do not intend to be a faster re-implementation of yesterday's graph DB.
+This file captures the **technical** target established on 2026-04-20: AI-agent workloads drive the feature set. Existing graph databases were designed in the pre-agent era; their storage layouts, query planners, and data types predate the workloads AI agents actually produce. We do not intend to be a faster re-implementation of yesterday's graph DB.
 
 The two pillars compound:
 
 | Motivation | Pillar |
 |------------|--------|
-| Commercial — the reason the project exists | End Neo4j lock-in; free, horizontally scalable, multi-tenant, Apache-2.0 |
+| Commercial — the reason the project exists | End incumbent lock-in; free, horizontally scalable, multi-tenant, Apache-2.0 |
 | Technical — the reason a user would pick us | AI-agent-native features natively: vectors, hybrid retrieval, media assets, agent memory, provenance, streaming results |
 
 ## What "AI-agent-native" concretely means
@@ -36,12 +36,12 @@ We commit to being best-in-class at the workloads below. Specifics live in [`ai-
 ## What stays from the generic graph DB promise
 
 - Full GQL (ISO/IEC 39075:2024) and openCypher support (ADR-0002).
-- Bolt v5 wire protocol for Neo4j-driver compatibility.
+- Bolt v5 wire protocol for migration-friendly driver compatibility.
 - ACID transactions with MVCC snapshot isolation.
 - Native multi-tenancy, horizontal scaling, online re-sharding.
 - Apache-2.0 end-to-end, no enterprise-gated features.
 
-These are necessary but not sufficient. They win migrations *from* Neo4j; AI-agent features win *new* workloads that never had a good graph DB answer.
+These are necessary but not sufficient. They win migrations from incumbent graph platforms; AI-agent features win *new* workloads that never had a good graph DB answer.
 
 ## Non-overlap with other categories
 


### PR DESCRIPTION
## What

Tighten the public requirements docs after the requirements fact-check pass.
This de-attributes the public wording, corrects AFM backrefs, expands and normalizes the aggregate
feature matrix, adds the missing public rows for external auth and managed service, and removes stray
text artifacts from the requirements set.

## Why

Refs #7.

These files are part of the M1 feature-lock surface. Before treating them as a stable lock input, the
public docs needed a second-pass audit to remove competitor attribution, fix incorrect AFM references,
and keep the aggregate aligned with the published public requirements surface.

## How

- Normalize `feature-matrix-aggregate.md` around the current AFM set.
- Update `feature-matrix.md` and `non-goals.md` to point at the corrected AFM ids.
- Add the missing public feature rows for external auth and managed service.
- Scrub competitor-named wording from `positioning.md` and `ai-agent-workloads.md`.
- Remove stale artifact text from `feature-matrix.md` and `performance-targets.md`.
- Re-run privacy and consistency checks so no public requirements doc names a competitor or codename.

## Checklist

- [x] Tests added: none (docs-only change)
- [x] Docs updated: `docs/requirements/*`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `mise exec -- cargo nextest run --workspace --all-features --no-tests=pass`
- [x] `cargo test --doc --workspace`
- [x] Privacy check: no `private/` paths staged; no competitor names or codenames in `docs/requirements/`
