### PR TITLE
docs(fm): lock M1 FM rows + split AFM-028 GDS taxonomy (Closes #7)

### DIFF
--- a/docs/requirements/feature-matrix-aggregate.md
+++ b/docs/requirements/feature-matrix-aggregate.md
@@ -30,7 +30,7 @@
 | AFM-025 | Hybrid graph + vector query composition | Query | 4 | Compose ANN retrieval with graph expansion and filtering in one plan | adopt |
 | AFM-026 | Full-text search | Query | 5 | Integrated text index and ranking inside the database query surface | adopt |
 | AFM-027 | Geospatial search | Query | 3 | Native geo types or geo indexes in graph-aware queries | adopt |
-| AFM-028 | Graph algorithms library | Query | 6 | Built-in or tightly coupled algorithm suite over stored graphs | adopt |
+| AFM-028 | Classical graph algorithms library | Query | 7 | Centrality, community-detection, pathfinding, and connectivity algorithms run over the stored graph or a tightly coupled analytics surface | adopt |
 | AFM-029 | Streaming ingest / CDC connectors | Ops | 2 | Native ingestion from message buses or change streams | adopt |
 | AFM-030 | High-speed bulk import | Ops | 5 | Dedicated large-scale loader separate from transactional writes | adopt |
 | AFM-031 | Backup / restore / disaster recovery | Ops | 3 | Operational tooling for snapshot, restore, and recovery workflows | adopt |
@@ -56,3 +56,10 @@
 | AFM-054 | Redis-module / protocol adjacency | Packaging | 1 | Graph engine runs as a module or adjacent surface over Redis | non-goal |
 | AFM-055 | Gremlin compatibility | Query | 1 | Support Gremlin as an additional graph query language | non-goal |
 | AFM-056 | Graph over external SQL / lakehouse tables | Storage | 1 | Map graph abstractions onto existing SQL or lakehouse tables | non-goal |
+| AFM-057 | Analytical graph projection / graph catalog workspace | Query | 2 | Project a filtered graph into an in-memory or temporary analytical workspace before running algorithms | redesign |
+| AFM-058 | Node / graph embedding algorithms | Query | 5 | Built-in embedding procedures such as node2vec or FastRP write vectors back into the graph | open |
+| AFM-059 | Supervised graph ML pipelines | Tooling | 4 | Train node-classification or link-prediction models over graph-derived features and graph structure | open |
+| AFM-060 | Python / notebook graph-data-science workflow | Tooling | 4 | Vendor-maintained Python or notebook APIs orchestrate projections, algorithms, and ML jobs | open |
+| AFM-061 | Managed or isolated graph analytics workbench / sessions | Tooling | 3 | Separate analytics sessions or workbenches isolate heavy graph-ML jobs from the primary OLTP surface | open |
+| AFM-062 | Third-party graph ML / analytics framework integration | Tooling | 4 | Adapters or data loaders bridge the graph store into PyG, DGL, NetworkX, cuGraph, Spark, or GraphX | open |
+| AFM-063 | Graph ML model catalog / inference APIs | Tooling | 3 | Persist trained graph models and expose prediction or model-inspection APIs inside the DS surface | open |

--- a/docs/requirements/feature-matrix.md
+++ b/docs/requirements/feature-matrix.md
@@ -30,9 +30,9 @@ Each row links to the governing ADR (if any), the tracking issue (once filed), a
 | FM-013 | query | B-tree + hash indices | Parity | M3 | — | — |
 | FM-014 | query | Full-text search on properties | Parity | M6 | — | — |
 | FM-015 | query | Native vector search integrated with graph traversal | Novel | M3 | — | — |
-| FM-016 | query | Built-in graph algorithms (BFS, DFS, PageRank, SSSP, WCC, Louvain) | Parity | M6 | — | — |
+| FM-016 | query | Built-in graph algorithms (BFS, DFS, PageRank, SSSP, WCC, Louvain) (AFM-028) | Parity | M6 | — | — |
 | FM-017 | query | Temporal / as-of queries | Novel | M6 | — | — |
-| FM-018 | query | Subgraph / snapshot materialisation | Novel | M8 | — | — |
+| FM-018 | query | Subgraph / snapshot materialisation (AFM-057) | Novel | M8 | — | — |
 | FM-019 | query | Compiled query plans (JIT via `cranelift` or AoT codegen) | Novel | M6 | — | — |
 | FM-020 | query | Vectorised execution for analytical workloads | Novel | M6 | — | — |
 | FM-021 | cluster | Raft-based metadata consensus (AFM-011) | Parity | M5 | ADR-0005 | — |
@@ -75,7 +75,7 @@ Every row below cites the workload family (from [`ai-agent-workloads.md`](./ai-a
 | FM-106 | ai-native | Hybrid query plans (ANN → graph expansion → rerank) in one plan | Novel | M3 | — | — | W-B |
 | FM-107 | ai-native | Full-text (BM25) index + `RRF` / `HYBRID` scoring operators | Parity | M6 | — | — | W-B |
 | FM-108 | ai-native | Multi-hop retrieval over heterogeneous schema (planner picks direction) | Novel | M4 | — | — | W-B, W-C |
-| FM-109 | ai-native | Built-in graph algorithms: PageRank, SSSP, BFS/DFS with early termination, Louvain, Leiden | Parity | M6 | — | — | W-C |
+| FM-109 | ai-native | Built-in graph algorithms: PageRank, SSSP, BFS/DFS with early termination, Louvain, Leiden (AFM-028) | Parity | M6 | — | — | W-C |
 | FM-110 | ai-native | Bi-temporal model (valid-time + transaction-time) + `AS OF` / `BETWEEN` | Novel | M6 | — | — | W-F |
 | FM-111 | ai-native | Per-fact TTL / forgetting curves + reinforcement primitive | Novel | M3 | — | — | W-A |
 | FM-112 | ai-native | Provenance (source, timestamp, extraction confidence) per node/edge | Novel | M3 | — | — | W-C |


### PR DESCRIPTION
## Summary
- Locks M1 FM rows (FM-001..FM-130) per issue #7 — de-attribute requirements, fix AFM mappings, add missing public AFM derivations.
- Splits `AFM-028 Graph algorithms library` (previously conflated analytics + GDS) into narrow `AFM-028 Classical graph algorithms library` + `AFM-057..063` for projection/catalog, node embeddings, supervised ML pipelines, Python/notebook DX, managed analytics sessions, third-party ML framework integration, and model catalog/inference APIs.
- Public backrefs: `FM-016 / FM-109 → AFM-028` (narrowed), `FM-018 → AFM-057`.

## Why
AFM-028 was carrying an entire product family (algorithms + embeddings + ML pipelines + Python DX + model catalog) in a single row, which made disposition decisions impossible. Decomposed per-layer rows keep the aggregate faithful to what competitors actually ship and let physa-db pick workload-anchored subsets later. AFM-058..063 stay `open` — no public FM promotion yet since the graph-ML workload anchor is still undecided.

## Test plan
- [x] Privacy — no competitor names, no codenames, no `private/` paths in the diff
- [x] Every AFM-* cited in private profiles exists in the public aggregate
- [x] FM backrefs point to existing AFM rows
- [ ] CI green (ubuntu + macos + conventional commits + privacy §7 + docs link check)

Closes #7