### PR TITLE
fix(infra): align workflow placeholders with repo contract

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -36,7 +36,7 @@ Companion infra: [`.github/workflows/reap-stale-claims.yml`](../../.github/workf
 | [`plan-feature`](./plan-feature/SKILL.md) | Before any code: locate FM row, workload anchor, first-principles derivation, acceptance criteria | §11, §15 |
 | [`write-adr`](./write-adr/SKILL.md) | ADR template with FM refs and quantitative derivation; always starts as Proposed | §11, §15 |
 | [`research-competitor`](./research-competitor/SKILL.md) | Codename-only private profile + attribution-free public delta | §7, ADR-0006 |
-| [`pre-commit-check`](./pre-commit-check/SKILL.md) | Local CI gate: fmt, clippy, tests, privacy check, secrets scan, conventional-commit | §§1, 4, 5, 7, 8 |
+| [`pre-commit-check`](./pre-commit-check/SKILL.md) | CI-core gate plus pre-commit-only checks: fmt, clippy, tests, privacy check, secrets scan, conventional-commit | §§1, 4, 5, 7, 8 |
 | [`review-pr`](./review-pr/SKILL.md) | Full reviewer checklist cross-referencing every applicable rule | §§1, 5, 7, 8, 11, 12, 15 |
 | [`promote-adr`](./promote-adr/SKILL.md) | Proposed → Accepted promotion, gated on feature lock + quantitative derivation | §15 |
 

--- a/.claude/skills/pre-commit-check/SKILL.md
+++ b/.claude/skills/pre-commit-check/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Run all physa-db pre-commit gates in one pass — formatting, clippy with
   -D warnings, tests, doc tests, private/ path check, conventional-commit
   message format, and a secrets scan. Must pass locally before any commit.
-  Mirrors what CI will run; if it passes here, it passes in CI.
+  Runs the CI core gate plus additional pre-commit-only checks such as
+  secrets scanning and commit-message validation.
 when_to_use: >
   "pre-commit", "check before commit", "ready to commit", right before
   staging a change for commit.
@@ -21,11 +22,15 @@ allowed-tools:
   - Grep
 ---
 
-# pre-commit-check — local gate mirroring CI
+# pre-commit-check — local gate aligned with CI core
 
 Run every gate below **in order** and report a single pass/fail summary at
 the end. Do not skip gates; if one fails, stop, report, and wait for the
 user to fix.
+
+This skill is intentionally a **superset** of the CI core gate. CI checks the
+shared workspace gate; this skill also checks local-only concerns such as
+staged secrets and commit-message shape.
 
 ## Gate 1 — Working tree sanity
 

--- a/.claude/skills/run-bench/SKILL.md
+++ b/.claude/skills/run-bench/SKILL.md
@@ -29,6 +29,10 @@ allowed-tools:
 claim ships with the exact command, hardware, dataset, before/after
 numbers, and std dev. This skill is the one legitimate path.
 
+If `just bench-macro` prints `status: placeholder`, stop there: the macro
+harness is not implemented yet, so the run only proves command wiring and may
+not be cited as a performance result.
+
 ## Pick the mode
 
 | Mode | Tool | What it measures | Stability |

--- a/.claude/skills/run-stress/SKILL.md
+++ b/.claude/skills/run-stress/SKILL.md
@@ -28,6 +28,9 @@ Stress scenarios surface bugs that unit and integration tests miss: crash
 recovery, soak-leak, hotspots, clock skew, network partitions. A scenario
 run is a signal, not a ceremony — read the output carefully.
 
+If `just stress` prints `status: placeholder`, the harness is not implemented
+yet. Treat that as wiring verification only, not evidence of correctness.
+
 ## Pick the right scenario
 
 | Scenario | Duration | When to use |
@@ -51,9 +54,10 @@ invariant list each scenario enforces.
 just stress {{scenario}}
 ```
 
-Under the hood this invokes the `physa-stress` subcommand of `physa-cli`
-which owns the dataset, workload generator, and invariant checker for
-the chosen scenario.
+Under the hood this invokes the `physa-stress` subcommand of `physa-cli`.
+During M0/M1 that subcommand is still a placeholder scaffold; once the real
+harness lands it will own the dataset, workload generator, and invariant
+checker for the chosen scenario.
 
 For long scenarios (`soak`, `supernode`), run in the background and
 monitor:

--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -47,6 +47,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Record hardware context
         id: hw
         run: |

--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -30,11 +30,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare:
+    name: determine whether iai gate should run
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Decide from labels and changed files
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if jq -e '.[] | select(. == "type:perf")' <<<"$labels" >/dev/null; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' \
+            | grep -Eq '^crates/.+/benches/'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
   iai:
-    # Skip unless the PR is explicitly labelled type:perf or changes benches.
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'type:perf') ||
-      contains(github.event.pull_request.changed_files.*.filename, '/benches/')
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
     name: iai instruction-count gate
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -47,6 +73,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,14 +120,14 @@ If no issue matches your task, **stop and open one first** via `file-issue`. Iss
 - **Unit tests:** in-file with `#[cfg(test)]`.
 - **Integration tests:** under `tests/integration/`.
 - **Property tests:** `proptest` for storage codecs, serialization, query planner equivalence.
-- **Fuzzing:** `cargo fuzz` targets for parser (GQL + Cypher), wire protocol, storage codec. Smoke run every PR, soak run weekly.
+- **Fuzzing:** `cargo fuzz` targets for parser (GQL + Cypher), wire protocol, storage codec. Until those targets land, `just fuzz-smoke` is a truthful scaffold that reports the gap without pretending coverage exists.
 - **Concurrency:** `loom` for lock-free / atomic code. No concurrency primitive ships without a `loom` test.
 - **Deterministic simulation:** `turmoil` (or equivalent) for cluster/network-partition scenarios.
-- **Benchmarks:** `criterion` for wall-time micro-benches, `iai-callgrind` for instruction-stable benches, custom harness in `benchmarks/` for macro (LDBC SNB, SNAP, YCSB). Run via `just bench` and `just bench-compare`.
-- **Stress tests:** `tests/stress/` holds chaos, soak, disk-full, OOM, partition scenarios. Run via `just stress`.
-- **Coverage:** tracked with `cargo llvm-cov`, reported in CI. Coverage is a diagnostic, not a target.
+- **Benchmarks:** `criterion` for wall-time micro-benches, `iai-callgrind` for instruction-stable benches, and a macro harness behind `just bench-macro`. During M0/M1 the macro command is a truthful placeholder scaffold until the real harness lands.
+- **Stress tests:** `tests/stress/` defines the target scenario matrix and `just stress` is the entrypoint. During M0/M1 the command is a truthful placeholder scaffold until the real harness lands.
+- **Coverage:** `cargo llvm-cov` is pinned for later use. Coverage reporting lands once the first non-trivial product-test surface exists. Coverage is a diagnostic, not a target.
 
-Every CI gate is a local `just` command — **if it passes locally, it must pass in CI**.
+Every **core** CI gate is a local `just` command — **if it passes locally, it must pass in CI**. Specialized workflows (for example `bench-regression`) may add extra checks on top.
 
 ---
 
@@ -136,7 +136,7 @@ Every CI gate is a local `just` command — **if it passes locally, it must pass
 **Single source of truth: GitHub Issues + GitHub Projects v2.** See ADR-0001.
 
 - Every task, bug, feature, research item is a GitHub Issue.
-- The GitHub Pages dashboard (`dashboard/`) reads a pre-generated `dashboard/data/state.json`, rebuilt by `snapshot-dashboard.yml` on every issue event.
+- The GitHub Pages dashboard (`dashboard/`) reads a pre-generated `dashboard/data/state.json`, rebuilt by `snapshot-dashboard.yml` when that workflow is enabled.
 - **Do not** create parallel tracking systems (TODO files, taskwarrior, etc.). If you need transient state inside a task, put it in a PR description or issue comment.
 
 ### Labels (canonical set)
@@ -206,7 +206,7 @@ See ADR-0006 for the full rationale.
   - `## Benchmarks` (required for `type:perf`) — before/after numbers, hardware, command.
   - `## Stress` (required for `type:stress` and any concurrency change) — scenario, duration, outcome.
   - `## Checklist` — tests added, docs updated, ADR if architectural.
-- **Required checks before merge:** `just ci` (which runs fmt + lint + test + fuzz-smoke + bench-regression-guard).
+- **Required checks before merge:** `just ci` (the shared core gate) plus any applicable specialized workflows such as `bench-regression`.
 
 ---
 

--- a/crates/physa-cli/Cargo.toml
+++ b/crates/physa-cli/Cargo.toml
@@ -12,6 +12,14 @@ description = "Command-line interface for physa-db (admin, import, query)."
 name = "physa"
 path = "src/main.rs"
 
+[[bin]]
+name = "physa-bench"
+path = "src/bin/physa-bench.rs"
+
+[[bin]]
+name = "physa-stress"
+path = "src/bin/physa-stress.rs"
+
 [lints]
 workspace = true
 

--- a/crates/physa-cli/src/bin/physa-bench.rs
+++ b/crates/physa-cli/src/bin/physa-bench.rs
@@ -1,0 +1,63 @@
+//! Placeholder macro-benchmark entrypoint.
+//!
+//! This keeps `just bench-macro` truthful during M0/M1: the command exists,
+//! parses the intended shape, and clearly reports that no real benchmark
+//! workload has executed yet.
+
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 2 && matches!(args[1].as_str(), "-h" | "--help") {
+        print_usage();
+        return ExitCode::SUCCESS;
+    }
+
+    let mut sf = String::from("1");
+    let mut iter = args.iter().skip(1);
+    let Some(cmd) = iter.next() else {
+        print_usage();
+        return ExitCode::FAILURE;
+    };
+
+    if cmd != "run" {
+        eprintln!("physa-bench: unsupported command `{cmd}`");
+        print_usage();
+        return ExitCode::FAILURE;
+    }
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--sf" => {
+                let Some(value) = iter.next() else {
+                    eprintln!("physa-bench: `--sf` requires a value");
+                    return ExitCode::FAILURE;
+                };
+                sf.clone_from(value);
+            }
+            "-h" | "--help" => {
+                print_usage();
+                return ExitCode::SUCCESS;
+            }
+            other => {
+                eprintln!("physa-bench: unsupported argument `{other}`");
+                print_usage();
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    println!("== physa-bench placeholder ==");
+    println!("command: run");
+    println!("scale factor: {sf}");
+    println!("status: placeholder");
+    println!("note: no LDBC/SNAP dataset was loaded and no benchmark was executed.");
+    println!("next step: replace this scaffold with the real harness tracked in issue #47.");
+
+    ExitCode::SUCCESS
+}
+
+fn print_usage() {
+    println!("Usage: physa-bench run [--sf <scale-factor>]");
+}

--- a/crates/physa-cli/src/bin/physa-stress.rs
+++ b/crates/physa-cli/src/bin/physa-stress.rs
@@ -1,0 +1,39 @@
+//! Placeholder stress-harness entrypoint.
+//!
+//! This keeps `just stress` truthful during M0/M1: the command exists,
+//! accepts the documented scenario argument, and clearly reports that no
+//! adversarial workload has run yet.
+
+use std::env;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 2 && matches!(args[1].as_str(), "-h" | "--help") {
+        print_usage();
+        return ExitCode::SUCCESS;
+    }
+
+    let scenario = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| String::from("smoke"));
+
+    if scenario.starts_with('-') {
+        eprintln!("physa-stress: unsupported option `{scenario}`");
+        print_usage();
+        return ExitCode::FAILURE;
+    }
+
+    println!("== physa-stress placeholder ==");
+    println!("scenario: {scenario}");
+    println!("status: placeholder");
+    println!("verdict: placeholder (no workload executed, no invariants checked)");
+    println!("note: replace this scaffold with the real harness tracked in issue #48.");
+
+    ExitCode::SUCCESS
+}
+
+fn print_usage() {
+    println!("Usage: physa-stress [scenario]");
+}

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -14,7 +14,9 @@ This directory holds the living design documentation for physa-db.
 1. **Draft** a new ADR as `adr/NNNN-kebab-title.md` using the template below.
 2. Status starts as **Proposed**.
 3. Discussion happens on the related GitHub issue (link it).
-4. Once merged, status becomes **Accepted**.
+4. **Process ADRs** may become **Accepted** on merge if they are not gated by
+   `AGENTS.md` §15. **Architectural ADRs** remain **Proposed** until the
+   relevant feature rows are locked and the ADR is promoted explicitly.
 5. If a later ADR invalidates this one, mark this one **Superseded by ADR-NNNN** — do NOT edit the body.
 
 ## ADR template

--- a/docs/architecture/adr/0001-project-tracking-store.md
+++ b/docs/architecture/adr/0001-project-tracking-store.md
@@ -1,8 +1,13 @@
 # ADR-0001: Project tracking — GitHub Issues + GitHub Projects v2, with a static JSON snapshot for the dashboard
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-20
+- **Accepted on:** 2026-04-20
 - **Context issue:** _(to be opened once repo is pushed)_
+
+> **Note on status.** ADR-0001 is a process ADR, not an architecture ADR gated
+> by `AGENTS.md` §15. It became Accepted once the project adopted GitHub Issues
+> + Projects v2 + the dashboard snapshot workflow as the tracking system.
 
 ## Context
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -2,12 +2,15 @@
 
 Performance claims without reproducible numbers are marketing. This directory defines **how** we benchmark, **what** we benchmark, and **where** results live.
 
+At M0/M1, only the micro-benchmark surface is implemented. `just bench-macro`
+is wired as a truthful placeholder scaffold until the real macro harness lands.
+
 ## Principles
 
 1. **Reproducible.** Every result must come with: command line, hardware spec, dataset version, commit SHA.
 2. **Comparative.** We run the same workload against the same hardware on at least two competitors (baseline = current market leader for that workload).
 3. **Honest.** We publish our losses too. Losses drive the roadmap.
-4. **Regression-gated.** A PR that regresses a tracked benchmark by >5% requires an ADR justifying the trade-off before merge.
+4. **Regression-gated.** A PR that regresses a tracked benchmark by >2% requires an ADR justifying the trade-off before merge.
 
 ## Layered benchmark strategy
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -31,8 +31,8 @@ That's it. The `just` recipes expose every other workflow you need.
 | Fuzz a target for 60 s | `just fuzz <target>` |
 | Micro benches | `just bench` |
 | Compare vs `main` | `just bench-compare main` |
-| Macro benches (LDBC SNB SF1) | `just bench-macro 1` |
-| Stress (chaos) | `just stress chaos` |
+| Macro benches (LDBC SNB SF1) | `just bench-macro 1` — placeholder scaffold at M0/M1 |
+| Stress (chaos) | `just stress chaos` — placeholder scaffold at M0/M1 |
 | Preview the dashboard | `just dashboard` then open http://localhost:8000 |
 | Check release automation | `just release-check` |
 | Check commit subjects | `just check-commits origin/main` |
@@ -87,6 +87,7 @@ just check-commits origin/main
 - **CI fails but `just ci` passes locally** → ensure you're on the same `mise` tool versions; check `mise ls` vs `.mise.toml`.
 - **Bench numbers unstable** → use `just bench-iai` for instruction-count benches; they're stable across hardware.
 - **Fuzz targets missing** → they live under `fuzz/` (created in M2+); list with `cargo fuzz list`.
+- **`just bench-macro` / `just stress` look too successful** → at M0/M1 these commands are intentionally wired as truthful placeholders. They prove command shape and documentation wiring, not benchmark or correctness evidence.
 
 ## Self-hosted bench runner
 
@@ -134,10 +135,11 @@ security risk and is intentionally avoided for PR-triggered runs.
        --component rustfmt --component clippy --no-modify-path
    '
    ```
-5. Install the Cargo helpers used by `just bench` and `just bench-iai`:
+5. Install the CLI helpers used by the benchmark workflows:
    ```bash
    sudo -u github-runner -H bash -lc '
      export PATH=/home/github-runner/.cargo/bin:$PATH
+     cargo install just --version 1.50.0 --locked
      cargo install cargo-criterion --version ^1.1 --locked
      cargo install iai-callgrind-runner --version ^0.14 --locked
    '

--- a/docs/requirements/performance-targets.md
+++ b/docs/requirements/performance-targets.md
@@ -1,6 +1,8 @@
 # Performance targets
 
-> Testable assertions. Every target is verified by `just bench-macro` against a known dataset and hardware profile.
+> Testable assertions. Verification runs through `just bench-macro` once the
+> real macro harness lands; at M0/M1 the command is only a truthful placeholder
+> scaffold.
 
 ## Reference hardware
 
@@ -56,5 +58,5 @@ CI fails any PR that regresses any cell in this document by > **2%** without an 
 
 All numbers are:
 1. Median of ≥ 10 runs after warm-up.
-2. Produced by `just bench-macro` and checked in under `docs/benchmarks/results/YYYY-MM-DD-*.md`.
+2. Produced by `just bench-macro` once the real harness exists, then checked in under `docs/benchmarks/results/YYYY-MM-DD-*.md`.
 3. Reproducible from commit SHA on the reference hardware.

--- a/docs/seed-issues.md
+++ b/docs/seed-issues.md
@@ -6,7 +6,7 @@ Each block below is ready to become a GitHub issue. When the repo is pushed to G
 gh issue create --title "<title>" --body-file <(echo "<body>") --label "<labels>"
 ```
 
-Or batch via `xtask create-seed-issues` (to be implemented).
+Or batch via `xtask seed-issues --dry-run` (current stub; real importer tracked separately).
 
 **Reminder:** competitor names must never appear in public issues. Use codenames (`Competitor ALPHA`, `BETA`, …). The codename↔name map is a local thread note, never committed. See ADR-0006.
 

--- a/justfile
+++ b/justfile
@@ -41,6 +41,15 @@ test-doc:
 fuzz target:
     cargo +nightly fuzz run {{target}} -- -max_total_time=60
 
+# Truthful placeholder for the future CI fuzz-smoke gate.
+fuzz-smoke:
+    @if find . -path '*/fuzz/Cargo.toml' -print -quit | grep -q .; then \
+        echo "fuzz-smoke: fuzz targets exist, but per-target smoke wiring is not implemented yet."; \
+        echo "fuzz-smoke: run \`just fuzz <target>\` explicitly until the dedicated gate lands."; \
+    else \
+        echo "fuzz-smoke: no fuzz targets exist yet; placeholder gate passes."; \
+    fi
+
 # ------------------------------------------------------------------
 # Benchmarks & stress — "all along the dev" per founder's rule.
 # ------------------------------------------------------------------
@@ -64,11 +73,23 @@ bench-save baseline="current":
 bench-iai:
     cargo bench -p physa-core --bench iai
 
+# Truthful placeholder for the future local regression gate.
+bench-regression-guard:
+    @if [[ "$(uname -s)" == "Linux" ]] && command -v valgrind >/dev/null 2>&1; then \
+        echo "bench-regression-guard: running iai smoke bench on Linux with valgrind."; \
+        cargo bench -p physa-core --bench iai; \
+    else \
+        echo "bench-regression-guard: skipping local iai run (needs Linux + valgrind)."; \
+        echo "bench-regression-guard: PR workflow remains the authoritative regression gate."; \
+    fi
+
 # Macro benchmarks (LDBC SNB / SNAP) on SF1.
+# M0/M1: this is a truthful placeholder scaffold until issue #47 lands.
 bench-macro sf="1":
     cargo run --release -p physa-cli --bin physa-bench -- run --sf {{sf}}
 
 # Run a stress scenario (chaos, soak, partition, disk-full, …).
+# M0/M1: this is a truthful placeholder scaffold until issue #48 lands.
 stress scenario="smoke":
     cargo run --release -p physa-cli --bin physa-stress -- {{scenario}}
 
@@ -76,8 +97,8 @@ stress scenario="smoke":
 # CI / release / docs
 # ------------------------------------------------------------------
 
-# The exact gate CI runs. Must pass locally before you push.
-ci: fmt-check lint test test-doc
+# The exact core gate CI runs. Must pass locally before you push.
+ci: fmt-check lint test test-doc fuzz-smoke bench-regression-guard
     @echo "CI gate passed."
 
 # Validate release-plz config and run a disposable local update.

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -2,6 +2,10 @@
 
 > Long-running, adversarial tests designed to surface bugs that unit/integration tests miss.
 
+At M0/M1, `just stress` is wired to a truthful placeholder scaffold. It proves
+the documented command shape and scenario naming, but it does **not** execute a
+real workload or verify invariants yet.
+
 ## Scenarios (to be implemented starting M2)
 
 | Scenario | What it does | Signal |
@@ -26,7 +30,10 @@ just stress soak         # release candidates only
 
 ## Harness
 
-Implemented in `physa-cli` as the `physa-stress` subcommand. Each scenario is self-contained: it owns its dataset, its workload generator, its invariant checkers. No scenario may share state with another.
+Implemented in `physa-cli` as the `physa-stress` subcommand. During M0/M1 this
+subcommand is a placeholder; the real harness lands later and each scenario
+will be self-contained with its own dataset, workload generator, and invariant
+checkers.
 
 ## Invariant checkers
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand};
 use xtask::dashboard;
 
 #[derive(Parser)]
@@ -30,7 +30,7 @@ enum Cmd {
     /// Create GitHub issues from `docs/seed-issues.md`.
     SeedIssues {
         /// If true, print what would be created without calling the API.
-        #[arg(long, default_value_t = true)]
+        #[arg(long, default_value_t = true, action = ArgAction::Set)]
         dry_run: bool,
     },
     /// Emit the agent prompt that walks through profiling a competitor codename.


### PR DESCRIPTION
## What

Align the workflow surface with the repo contract by replacing dead references with executable placeholders, fixing broken wiring, and reconciling docs/skills/governance text with what the repo actually enforces.

## Why

Refs #45.

Several mandatory commands and rules had drifted from reality: `just stress` and `just bench-macro` pointed at missing binaries, `seed-issues` was wired incorrectly, CI/docs/skills described different gates, and ADR status guidance conflicted across the repo.

## How

- add placeholder `physa-bench` and `physa-stress` entrypoints so the documented command surface exists and reports placeholder status truthfully
- fix `xtask seed-issues` flag parsing and update seed/docs language to match its current stub state
- extend `just ci` with truthful placeholder `fuzz-smoke` and `bench-regression-guard` recipes, then align docs and skills around the CI-core vs local-only distinction
- repair `bench-regression.yml` file-change detection by querying PR files through GitHub instead of assuming invalid payload fields
- clarify ADR process docs and mark ADR-0001 as an accepted process ADR

## Benchmarks

N/A. This is infra/docs/workflow repair, not a performance change.

## Stress

N/A as evidence of system correctness. The only stress-related verification here is command-surface wiring:

```bash
just stress smoke
```

which now executes the placeholder harness and reports its placeholder status explicitly.

## Checklist

- [x] `just ci`
- [x] `just stress smoke`
- [x] `just bench-macro 1`
- [x] `just seed-issues`
- [x] Docs updated in the same PR
- [x] No competitor names or `private/` references added
