### PR TITLE
chore(infra): bump actions/checkout v4 -> v6 (Node 24)

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -45,7 +45,7 @@ jobs:
       PATH: /home/github-runner/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install just
         uses: taiki-e/install-action@v2

--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -70,7 +70,7 @@ jobs:
       REGRESSION_THRESHOLD: "2.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install just and cargo-nextest
         uses: taiki-e/install-action@v2
@@ -44,7 +44,7 @@ jobs:
     name: privacy tree check (§7)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: No private/ paths tracked
         run: |
           leaked=$(git ls-files private/)
@@ -57,7 +57,7 @@ jobs:
     name: docs link check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: lycheeverse/lychee-action@v2
         with:
           args: --verbose --no-progress --exclude-loopback './**/*.md'

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,7 +13,7 @@ jobs:
     name: conventional commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate PR title
         env:

--- a/.github/workflows/reap-stale-claims.yml
+++ b/.github/workflows/reap-stale-claims.yml
@@ -41,7 +41,7 @@ jobs:
       CLAIM_TTL_HOURS: ${{ inputs.ttl_hours || '24' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'mroche14' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -37,7 +37,7 @@ jobs:
     needs: release-plz-release
     if: ${{ github.repository_owner == 'mroche14' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/snapshot-dashboard.yml
+++ b/.github/workflows/snapshot-dashboard.yml
@@ -36,7 +36,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Reconcile declared labels
         shell: bash


### PR DESCRIPTION
## Summary

Clears the CI warning surfaced in annotations: *"Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting January 2027."*

Bumps all 11 occurrences of `actions/checkout@v4` to `@v6` across 8 workflow files. `v6` is the current stable major (v6.0.2, 2026-01-09) and runs on Node 24.

## Scope

| Workflow | Occurrences |
|---|---|
| `ci.yml` | 3 |
| `release-plz.yml` | 2 |
| `bench-nightly.yml` | 1 |
| `bench-regression.yml` | 1 |
| `conventional-commits.yml` | 1 |
| `reap-stale-claims.yml` | 1 |
| `snapshot-dashboard.yml` | 1 |
| `sync-labels.yml` | 1 |

## Other actions — no bump needed

Verified already on Node-24-compatible majors:

- `Swatinem/rust-cache@v2` (v2.9.1 latest)
- `taiki-e/install-action@v2` (2.75.19 latest)
- `lycheeverse/lychee-action@v2` (v2.8.0 latest)
- `actions/upload-artifact@v4`
- `actions/configure-pages@v5`
- `actions/upload-pages-artifact@v3`
- `actions/deploy-pages@v4`

## Test plan

- [ ] CI green on all 4 required checks (`just ci (ubuntu-latest)`, `just ci (macos-latest)`, `conventional commits`, `privacy tree check (§7)`).
- [ ] No Node 20 deprecation annotation on the CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)