### PR TITLE
chore(docs): collapse agent bridge + unify dev onboarding

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,20 +1,32 @@
 # Codex skill bridge
 
-Codex discovers repository-scoped skills from `.agents/skills/`.
+Codex discovers repository-scoped skills from `.agents/skills/`. physa-db keeps
+its canonical skill definitions in `.claude/skills/`, and `.agents/skills` is a
+**single directory-level symlink** to that canonical location:
 
-The project already keeps its canonical skill definitions in `.claude/skills/`.
-Each entry in `.agents/skills/` is therefore a symlink to the matching Claude
-skill directory. This keeps one source of truth while making the same `SKILL.md`
-files visible to Codex.
+```
+.agents/skills -> ../.claude/skills
+```
 
-If you add, rename, or remove a project skill under `.claude/skills/`, refresh
-the bridge from the repository root:
+Every skill that lives under `.claude/skills/<name>/` is therefore automatically
+visible to Codex at `.agents/skills/<name>/`. No per-skill symlink to maintain,
+no "refresh the bridge" step when you add or remove a skill.
+
+If `.agents/skills/` ever looks broken (empty or showing a stale set of entries)
+— most likely because a tool that doesn't follow symlinks well clobbered it —
+recreate it from the repository root:
 
 ```bash
-mkdir -p .agents/skills
-for skill in .claude/skills/*; do
-  [ -d "$skill" ] || continue
-  name=$(basename "$skill")
-  ln -sfn "../../.claude/skills/$name" ".agents/skills/$name"
-done
+rm -rf .agents/skills
+ln -s ../.claude/skills .agents/skills
+git add .agents/skills
 ```
+
+Invocation syntax differs by agent:
+
+- **Claude Code** — slash commands (`/next`, `/plan-feature`, …).
+- **Codex** — prefix invocation (`$next`, `$plan-feature`, …) or "use the named
+  skill" in a prompt.
+
+Skill semantics, allowed-tools, and argument hints are identical across agents —
+the `SKILL.md` file is the single source of truth.

--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.agents/skills/abandon
+++ b/.agents/skills/abandon
@@ -1,1 +1,0 @@
-../../.claude/skills/abandon

--- a/.agents/skills/file-issue
+++ b/.agents/skills/file-issue
@@ -1,1 +1,0 @@
-../../.claude/skills/file-issue

--- a/.agents/skills/next
+++ b/.agents/skills/next
@@ -1,1 +1,0 @@
-../../.claude/skills/next

--- a/.agents/skills/onboard
+++ b/.agents/skills/onboard
@@ -1,1 +1,0 @@
-../../.claude/skills/onboard

--- a/.agents/skills/plan-feature
+++ b/.agents/skills/plan-feature
@@ -1,1 +1,0 @@
-../../.claude/skills/plan-feature

--- a/.agents/skills/pre-commit-check
+++ b/.agents/skills/pre-commit-check
@@ -1,1 +1,0 @@
-../../.claude/skills/pre-commit-check

--- a/.agents/skills/promote-adr
+++ b/.agents/skills/promote-adr
@@ -1,1 +1,0 @@
-../../.claude/skills/promote-adr

--- a/.agents/skills/research-competitor
+++ b/.agents/skills/research-competitor
@@ -1,1 +1,0 @@
-../../.claude/skills/research-competitor

--- a/.agents/skills/review-pr
+++ b/.agents/skills/review-pr
@@ -1,1 +1,0 @@
-../../.claude/skills/review-pr

--- a/.agents/skills/run-bench
+++ b/.agents/skills/run-bench
@@ -1,1 +1,0 @@
-../../.claude/skills/run-bench

--- a/.agents/skills/run-stress
+++ b/.agents/skills/run-stress
@@ -1,1 +1,0 @@
-../../.claude/skills/run-stress

--- a/.agents/skills/write-adr
+++ b/.agents/skills/write-adr
@@ -1,1 +1,0 @@
-../../.claude/skills/write-adr

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -8,9 +8,11 @@
 Each subdirectory is one skill with a `SKILL.md` file. Claude Code exposes
 project skills as slash commands (`/plan-feature`, `/run-stress chaos`, etc.),
 or auto-invokes a skill when its description matches the user's request. Codex
-reads the same canonical skill directories through the `.agents/skills/`
-symlink bridge, but Codex skills are invoked with `$plan-feature`,
-`$run-stress`, etc., or by asking Codex to use the named skill.
+reads the same canonical skill directories through a single directory-level
+symlink (`.agents/skills -> ../.claude/skills`) — adding or removing a skill
+here makes it visible to Codex automatically, no bridge-refresh step. Codex
+skills are invoked with `$plan-feature`, `$run-stress`, etc., or by asking
+Codex to use the named skill.
 
 Skills exist to make **rules mechanical**. Rather than trusting every agent
 to remember `AGENTS.md` §§7, 11, 12, 15 from memory, skills bake the relevant
@@ -68,7 +70,8 @@ These are on the backlog; open an issue if you need one before it ships.
 - **Scope.** Every canonical skill lives under `.claude/skills/<name>/SKILL.md`.
   Project-level. No personal skills (`~/.claude/skills/`) — they would be
   invisible to agents running on another machine. Codex compatibility is handled
-  by `.agents/skills/<name>` symlinks that point back to these directories.
+  automatically by the `.agents/skills -> ../.claude/skills` directory symlink —
+  add a skill here, it shows up for Codex on its own.
 - **Frontmatter.** `name` (optional; defaults to directory name), `description`
   (used by Claude to decide auto-invocation — front-load keywords),
   `when_to_use` (trigger phrases), `argument-hint`, `user-invocable`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,7 +356,7 @@ M1 (see `ROADMAP.md`) is the milestone where all primary feature rows move from 
 
 ## 16. Skills — mechanical rule enforcement
 
-The repo ships a catalog of skills under [`.claude/skills/`](./.claude/skills/). Each skill is a playbook that enforces one or more of the rules above so they are checked mechanically, not recalled from memory. Codex discovers the same canonical skill files through the symlink bridge under [`.agents/skills/`](./.agents/skills/); keep `.claude/skills/` as the source of truth and refresh the bridge when skills are added, renamed, or removed.
+The repo ships a catalog of skills under [`.claude/skills/`](./.claude/skills/). Each skill is a playbook that enforces one or more of the rules above so they are checked mechanically, not recalled from memory. Codex discovers the same canonical skill files through a single directory-level symlink (`.agents/skills -> ../.claude/skills`); a skill added, renamed, or removed under `.claude/skills/` is immediately visible to Codex — no bridge-refresh step.
 
 Invocation syntax differs by agent. Claude Code exposes these as slash commands such as `/next`. Codex skills are not CLI slash commands; invoke them with `$next`, `$plan-feature`, etc., or by asking Codex to use the named skill.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,54 +1,129 @@
 # Contributing to physa-db
 
-Welcome. This project is designed so both humans and AI agents can contribute with a minimum of friction.
+physa-db is developed with AI coding agents (Claude Code, Codex, Cursor, …). Whether you are the solo maintainer or a brand-new external contributor, the workflow is the same: open an agent in the repo, run `/onboard`, then `/next`. The skills shipped in [`.claude/skills/`](./.claude/skills/) encode every rule from [`AGENTS.md`](./AGENTS.md) so you don't have to memorise them — invoking the right skill at the right moment is enough.
 
-## If you are a human contributor
+## Contents
 
-1. Read [`README.md`](./README.md) and [`ROADMAP.md`](./ROADMAP.md).
-2. Skim [`AGENTS.md`](./AGENTS.md) — it describes how the project is driven day-to-day. The rules apply to you too, not just to AI agents.
-3. Pick an open issue labelled `status:ready`. Comment that you're picking it up.
-4. Branch from `main` as `human/<gh-handle>/<slug>` (reserved `agent/*` prefix for AI agents).
-5. Open a PR using the template. Expect review within 48h.
+- [Quickstart](#quickstart)
+- [The dev loop, step by step](#the-dev-loop-step-by-step)
+- [Skills by moment](#skills-by-moment)
+- [Error recovery](#error-recovery)
+- [Issue lifecycle](#issue-lifecycle)
+- [Branch & commit conventions](#branch--commit-conventions)
+- [Code of conduct](#code-of-conduct)
+- [Licensing](#licensing)
+- [Security](#security)
 
-## If you are an AI agent
+## Quickstart
 
-The entire workflow is encoded as project skills versioned under [`.claude/skills/`](./.claude/skills/) (Claude Code) and mirrored via symlinks under [`.agents/skills/`](./.agents/skills/) (Codex). A fresh clone already has every skill you need — no separate install.
-
-**First session (one-time setup):**
+**Prerequisites:** [`mise`](https://mise.jdx.dev/) · `git` · `gh` (GitHub CLI — `/next` needs it authenticated).
 
 ```bash
 git clone https://github.com/mroche14/physa-db.git
 cd physa-db
-mise install         # pinned toolchain: Rust, just, nextest, criterion, …
-gh auth login        # the /next skill claims GitHub Issues atomically
+claude .            # or: codex, cursor, …
 ```
 
-Then open your agent in the repo (Claude Code, Codex, Cursor, …) and run:
+Then, inside your agent:
 
-1. **`/onboard`** — mandatory first read: two pillars, rules (§§7, 11, 12, 15), reading order.
-2. **`/next`** — claims the next `status:ready` issue atomically, creates `agent/<n>-<slug>` branch, and either invokes `/plan-feature` or resumes prior work.
+1. **`/onboard`** — installs the pinned toolchain (`mise install`), verifies `gh auth`, reads the rules and pillars, lists ready tasks. Run it first in every fresh session and after any context-compaction.
+2. **`/next`** — claims the next `status:ready` GitHub Issue atomically, creates the `agent/<n>-<slug>` branch, and invokes `/plan-feature` if the issue has no plan yet.
 
-**While working:**
+After that, you're inside the dev loop.
 
-| Skill | When |
+Codex syntax: the same skills are invoked with `$onboard`, `$next`, `$plan-feature`, etc. — or by asking Codex to "use the `<name>` skill".
+
+## The dev loop, step by step
+
+```
+/onboard → /next → /plan-feature → [code + tests] → /pre-commit-check → commit + push → gh pr create → /wait-ci
+                                                                                                          ├─ ✅ green   → done
+                                                                                                          ├─ ❌ fail    → fix & repush  OR  /abandon blocked
+                                                                                                          └─ ⏳ timeout → surface & resume later
+```
+
+| # | Step | What happens |
+|---|---|---|
+| 1 | `/onboard` | Env bootstrap (`mise install` + `gh auth status`) · read AGENTS.md §§0–2, 11, 12, 15 · list `status:ready` + `agent:good-first-task` |
+| 2 | `/next` | Atomically claim a ready issue (sets `status:in-progress` + `assignee`) · create `agent/<n>-<slug>` branch off up-to-date `main` · sync remote, prune stale branches |
+| 3 | `/plan-feature` | Locate the FM row · identify workload anchor in `ai-agent-workloads.md` · first-principles derivation · lock acceptance criteria · decide whether an ADR is needed |
+| 3b | `/write-adr` *(conditional)* | ADR template with FM refs and quantitative derivation — always starts as Proposed |
+| 4 | Write code + tests | Follow AGENTS.md §§1, 4, 11, 12. No `unimplemented!()` stubs. Cite research inline. |
+| 5 | `/run-stress` *(conditional)* | Mandatory evidence for any PR touching storage / MVCC / cluster (AGENTS.md §5) |
+| 5b | `/run-bench` *(conditional)* | Mandatory evidence for any PR labelled `type:perf` (AGENTS.md §§1.2, 8) |
+| 6 | `/pre-commit-check` | Local mirror of the CI gate: fmt, clippy, tests, doc-tests, link-check, private path check, secrets scan, conventional commit subject |
+| 7 | `git commit && git push && gh pr create` | Conventional commit subject · PR template auto-fills summary + test plan · branch `agent/<n>-<slug>` carries the issue number |
+| 8 | `/wait-ci` | Poll CI, walk the PR test-plan checklist, report the verdict on the PR · returns `success` / `pending-human` / `fail` (see [#52](https://github.com/mroche14/physa-db/issues/52) for current status of this skill) |
+
+"Done" is **PR green + checklist resolved**, not "PR open". See AGENTS.md §6.1.
+
+## Skills by moment
+
+The skills catalog organised by *when to use*, not by tier. Every skill lives under `.claude/skills/<name>/SKILL.md` and is visible to Codex via the directory symlink `.agents/skills -> ../.claude/skills`.
+
+| Moment | Skill | Enforces | Mandatory for |
+|---|---|---|---|
+| Start of session | [`/onboard`](.claude/skills/onboard/SKILL.md) | all rules | every new agent session |
+| Pick up work | [`/next`](.claude/skills/next/SKILL.md) | §§3, 6.1 | every new task |
+| Before code | [`/plan-feature`](.claude/skills/plan-feature/SKILL.md) | §§11, 15 | every feature / behavioural change |
+| Design doc | [`/write-adr`](.claude/skills/write-adr/SKILL.md) | §§11, 15 | when `/plan-feature` flagged it |
+| Competitor research | [`/research-competitor`](.claude/skills/research-competitor/SKILL.md) | §7, ADR-0006 | any competitor profile |
+| Before commit | [`/pre-commit-check`](.claude/skills/pre-commit-check/SKILL.md) | §§1, 4, 5, 7, 8 | every commit |
+| Storage / MVCC / cluster change | [`/run-stress`](.claude/skills/run-stress/SKILL.md) | §5 | every such PR |
+| Perf claim | [`/run-bench`](.claude/skills/run-bench/SKILL.md) | §§1.2, 8 | every `type:perf` PR |
+| After push | `/wait-ci` *(see [#52](https://github.com/mroche14/physa-db/issues/52))* | §6.1 | every `gh pr create` |
+| Reviewing a PR | [`/review-pr`](.claude/skills/review-pr/SKILL.md) | §§1, 5, 7, 8, 11, 12, 15 | every PR review |
+| Track follow-up | [`/file-issue`](.claude/skills/file-issue/SKILL.md) | §6 | any task > 1 h of effort |
+| Can't finish | [`/abandon`](.claude/skills/abandon/SKILL.md) | §§3, 6.1 | every unfinished task |
+| Promote ADR to Accepted | [`/promote-adr`](.claude/skills/promote-adr/SKILL.md) | §15 | M2 exit |
+
+**Rule (AGENTS.md §16):** if a skill exists for the action you are about to take, use it. A PR that could have been produced via `plan-feature` + `write-adr` + `pre-commit-check` but skipped them is evidence that the author missed a rule.
+
+## Error recovery
+
+| Situation | Action |
 |---|---|
-| `/plan-feature <desc>` | Before any code. Locks FM row + workload anchor + derivation + acceptance criteria |
-| `/write-adr <NNNN> <title>` | When `/plan-feature` concluded an ADR is needed |
-| `/research-competitor <CODENAME>` | Any competitor profile — codename-only, private input, public delta |
-| `/pre-commit-check` | Before every commit — local mirror of the CI gate |
-| `/run-stress <scenario>` | After any storage / MVCC / cluster change (mandatory evidence) |
-| `/run-bench <mode> <baseline>` | Before claiming any perf win (mandatory for `type:perf` PRs) |
-| `/review-pr <num>` | Reviewing any PR |
-| `/file-issue <title>` | Any tracked task > 1 h of effort |
-| `/abandon ready <reason>` | When you can't finish — always releases the claim, never walk away silently |
+| `/next` finds no ready task | Check `status:blocked` for work waiting on you. If nothing fits, there genuinely is no ready work — surface it to the human. |
+| `/plan-feature` can't locate the FM row for the issue | The issue is under-specified. Run `/abandon blocked "missing FM row"`, file a `needs-spec` follow-up issue, exit. |
+| `/pre-commit-check` fails | Fix the reported issue (fmt / clippy / tests / secrets / private path). Re-run until green. Never `--no-verify`. |
+| CI red after push (your change) | `/wait-ci` (or `gh pr checks <n>`) gives you the failing job + logs. Fix, commit, push, `/wait-ci` again. |
+| CI red after push (pre-existing rot, not your diff) | File a follow-up issue via `/file-issue`, add a surgical exclusion in the config that owns it (e.g. `lychee.toml`), reference the follow-up issue in the exclusion comment. Keeps your PR mergeable without papering over the root cause. |
+| You are stuck (context / dependency / environment) | `/abandon blocked "<reason>"` — releases the claim back to the pool. Don't walk away silently. |
+| Session ended mid-task, claim still yours | New session: `/onboard` then `/next`. The skill sees your existing claim and resumes instead of claiming a new issue. |
+| Context lost to compaction | `/onboard` again — it's idempotent and designed to re-hydrate. |
+| You left a dormant claim > 24 h | [`reap-stale-claims.yml`](.github/workflows/reap-stale-claims.yml) reverts it to `status:ready` automatically. No cleanup needed from you. |
 
-Codex users: invoke the same skills with `$onboard`, `$next`, `$plan-feature`, etc.
+## Issue lifecycle
 
-**Full contract:** read [`AGENTS.md`](./AGENTS.md) §§0–16 in full before touching anything. It is authoritative.
+```
+          ┌──────────── /next ────────────┐
+          │                               ▼
+  status:ready ──────────────────→ status:in-progress + assignee
+          ▲                               │
+          │ reap-stale-claims             │ open PR
+          │ (> 24 h dormant)              ▼
+          │                          PR open (CI runs)
+          │                               │
+          │   /abandon ready              │ /wait-ci → green
+          ├───────────────────────────────┤
+          │                               ▼
+          │                         PR merged → issue closed
+          │
+  status:blocked ← /abandon blocked (needs-human / waiting on dep)
+```
+
+A claim is always live — an agent holds it (assignee + `status:in-progress`), or releases it (`/abandon` → `ready` / `blocked`), or closes it via merged PR. No silent walk-aways.
+
+## Branch & commit conventions
+
+- **Branch names:** `agent/<issue-n>-<slug>` (AI agents, set by `/next`) · `human/<gh-handle>/<slug>` (human contributors) · `chore/<scope>-<slug>` (infra / DX / docs not tied to a feature issue).
+- **Commit subjects:** [Conventional Commits](https://www.conventionalcommits.org/) — `type(scope): imperative subject`. Enforced by the `Conventional Commits` CI check.
+- **PR size:** ≤ 600 lines non-generated code. If bigger, split (AGENTS.md §1.4).
+- **PR body:** use the template. Fill the `## Test plan` section with imperative checklist items — `/wait-ci` pattern-matches them against its predicate library.
 
 ## Code of conduct
 
-Be excellent. Detailed CoC to be added; in the meantime, the Rust community norms apply.
+Be excellent. A detailed CoC will follow; in the meantime, the Rust community norms apply.
 
 ## Licensing
 
@@ -56,4 +131,4 @@ By contributing, you agree that your contribution is licensed under Apache-2.0, 
 
 ## Security
 
-Please do NOT open public issues for security vulnerabilities. Contact the maintainer at `55630565+mroche14@users.noreply.github.com` (temporary; a security policy will be set up with M0).
+Do **not** open public issues for security vulnerabilities. Use GitHub's private vulnerability reporting: [report a security issue](https://github.com/mroche14/physa-db/security/advisories/new). Details in [`SECURITY.md`](./SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@
 - [Why physa-db?](#why-physa-db)
 - [Built by AI agents, on purpose](#built-by-ai-agents-on-purpose)
 - [Getting started](#getting-started)
-  - [As a human contributor](#as-a-human-contributor)
-  - [As an AI agent](#as-an-ai-agent)
+- [The dev loop](#the-dev-loop)
 - [Status & dashboard](#status--dashboard)
 - [Project labels](#project-labels)
 - [Quick links](#quick-links)
@@ -122,38 +121,35 @@ See [`AGENTS.md`](./AGENTS.md) for the full agent contract — engineering-disci
 
 ## Getting started
 
-**Prerequisites:** [`mise`](https://mise.jdx.dev/) · `git` · `gh` (GitHub CLI authenticated via `gh auth login`).
+physa-db is developed with AI coding agents — Claude Code, Codex, Cursor, or anything that honours [`.claude/skills/`](./.claude/skills/) (Codex reads the same files through [`.agents/skills/`](./.agents/skills/)). Whether you are the solo maintainer or a new external contributor, the workflow is identical: open an agent, run `/onboard`, then `/next`.
 
-### As a human contributor
-
-```bash
-git clone https://github.com/mroche14/physa-db.git
-cd physa-db
-mise install        # pinned toolchain (Rust + just + nextest + criterion + …)
-just dev            # watch-mode tests + clippy
-```
-
-Then read [`CONTRIBUTING.md`](./CONTRIBUTING.md), pick an open issue labelled [`status:ready`](https://github.com/mroche14/physa-db/issues?q=is%3Aopen+is%3Aissue+label%3Astatus%3Aready), and branch from `main` as `human/<gh-handle>/<slug>`.
-
-### As an AI agent
-
-Works with Claude Code, Codex, Cursor, or any agent that honours [`.claude/skills/`](./.claude/skills/).
+**Prerequisites:** [`mise`](https://mise.jdx.dev/) · `git` · `gh` (GitHub CLI — `/next` needs it authenticated).
 
 ```bash
 git clone https://github.com/mroche14/physa-db.git
 cd physa-db
-mise install
-gh auth login       # /next claims GitHub Issues atomically — gh must be authenticated
+claude .            # or: codex, cursor, …
 ```
 
-Open your agent in the repo directory. Every project skill auto-loads from [`.claude/skills/`](./.claude/skills/) (or [`.agents/skills/`](./.agents/skills/) for Codex) — no separate install.
+Then, inside your agent:
 
-Then run, in order:
+1. **`/onboard`** — installs the pinned toolchain (`mise install`), verifies `gh auth`, reads rules + pillars, lists ready tasks. Run this first in every fresh session (and after any context-compaction). *(Auto-install behaviours are tracked for implementation — see [#52](https://github.com/mroche14/physa-db/issues/52) and the follow-up `/onboard` enrichment issue.)*
+2. **`/next`** — claims the next `status:ready` GitHub Issue atomically, creates the `agent/<n>-<slug>` branch, and invokes `/plan-feature` if the issue has no plan yet.
 
-1. **`/onboard`** — mandatory first read: pillars, rules, causal chain, reading order.
-2. **`/next`** — claims the next `status:ready` issue, creates `agent/<n>-<slug>` branch, invokes `/plan-feature` if needed.
+That's the entry gate. The full loop (`/plan-feature` → code → `/pre-commit-check` → commit → push + PR → `/wait-ci`) plus error-recovery paths and the skills-by-moment reference live in [`CONTRIBUTING.md`](./CONTRIBUTING.md). The complete agent contract — rules §§1–15, claim protocol §6.1, skills catalog §16 — lives in [`AGENTS.md`](./AGENTS.md).
 
-Everything else (`/plan-feature`, `/write-adr`, `/pre-commit-check`, `/run-stress`, `/run-bench`, `/review-pr`, `/file-issue`, `/abandon`) is documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`AGENTS.md`](./AGENTS.md) §16.
+## The dev loop
+
+```
+/onboard → /next → /plan-feature → [code] → /pre-commit-check → commit + push → gh pr create → /wait-ci
+                                                                                                    ├─ ✅ green   → done
+                                                                                                    ├─ ❌ fail    → fix & repush  OR  /abandon blocked
+                                                                                                    └─ ⏳ timeout → surface & resume later
+```
+
+Each arrow is a skill or a standard git/gh command. Skills exist to make the AGENTS.md rules mechanical — you don't memorise them, you invoke the right skill at the right moment. If a skill exists for the action you are about to take, use it (AGENTS.md §16).
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the detailed step-by-step, the full skills-by-moment reference, and what to do when a step fails.
 
 ## Status & dashboard
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,11 @@
 
 Please **do not** open public GitHub issues for security vulnerabilities.
 
-Until a dedicated security contact is set up, report privately to:
+Use GitHub's private vulnerability reporting — it keeps the report confidential until a fix ships:
 
-- Email: `55630565+mroche14@users.noreply.github.com`
-- Subject line: `physa-db security — <short description>`
+> **Report a vulnerability →** https://github.com/mroche14/physa-db/security/advisories/new
 
-We will acknowledge within 72h. Once the fix is in, we will publish a GHSA advisory and credit you (or keep it anonymous, your choice).
+We will acknowledge within 72h. Once the fix is in, we publish a GHSA advisory and credit you (or keep it anonymous, your choice).
 
 ## Supported versions
 


### PR DESCRIPTION
## Summary

Two coupled improvements to the contributor experience.

### 1. Codex bridge is now a single directory-level symlink

Today `.agents/skills/` contains **12 individual symlinks**, one per skill. Adding a new skill under `.claude/skills/` requires remembering to create the corresponding `.agents/skills/<name>` symlink — a manual step that silently breaks Codex parity when forgotten.

Replace with one directory-level symlink:

```
.agents/skills -> ../.claude/skills
```

Adding, renaming, or removing a skill under `.claude/skills/` is now instantly visible to Codex with zero additional gestures.

Updates `.agents/README.md`, `.claude/skills/README.md`, and `AGENTS.md` §16 to describe the new mechanism.

### 2. Unified Getting Started + detailed dev loop

The README's previous split ("As a human contributor" / "As an AI agent") mis-framed the project. Every contributor on physa-db drives an AI agent. Replace with one unified quickstart and a diagrammed dev loop.

CONTRIBUTING.md expanded from 60 lines to a real dev-process document:

| Section | Content |
|---|---|
| Quickstart | 3-step — clone, open agent, `/onboard` + `/next` |
| The dev loop, step by step | 8-row table mapped to the flow diagram |
| Skills by moment | Catalog organised by *when*, not by tier |
| Error recovery | 9 common situations + the deterministic action for each |
| Issue lifecycle | ASCII state diagram (ready → in-progress → blocked ↔ reap) |
| Branch & commit conventions | `agent/` vs `human/` vs `chore/` + conventional commits |

Forward references to `/wait-ci` link to issue #52 so the placeholder is visible but harmless until the skill ships.

### Related polish

Route security reports through GitHub's built-in [private vulnerability reporting](https://github.com/mroche14/physa-db/security/advisories/new) in SECURITY.md and CONTRIBUTING.md — standard OSS hygiene, keeps reports confidential until a fix ships.

## Why now

Post public-open, the onboarding path is the first thing external contributors see — it should be unambiguous and agent-shaped from the start.

## Test plan

- [ ] `ls -la .agents/skills` shows a single symlink pointing to `../.claude/skills`.
- [ ] `cat .agents/skills/next/SKILL.md` resolves via the symlink and returns the canonical skill content.
- [ ] README renders on GitHub with the unified Getting Started and the dev-loop ASCII diagram intact.
- [ ] CONTRIBUTING.md Contents TOC links all resolve (all anchors use standard slugs).
- [ ] All 4 required CI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)