### PR TITLE
fix(infra): stop leaking user.email via /next + codify no-PII rule

### DIFF
--- a/.claude/skills/abandon/SKILL.md
+++ b/.claude/skills/abandon/SKILL.md
@@ -149,3 +149,7 @@ immediately claimable.
   next task.
 - Do not `/abandon` and leave yourself as assignee. The whole point
   is to release the claim; keeping the assignee defeats the protocol.
+- Do not put personal information (email, legal name, home path,
+  hostname) into the `$REASON` or the follow-up comment. The comment
+  is public. AGENTS.md §10 forbids PII on public surfaces; refer to
+  yourself only by the GitHub handle the assignee already exposes.

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -164,3 +164,7 @@ Or via the browser with the template pre-filled if you prefer the UI.
   `plan-feature` first to add it.
 - Do not use `status:in-progress` at creation time. Start at
   `status:ready`; the agent picking up the work flips it.
+- Do not include personal information in the issue body (email
+  addresses, legal names, phone numbers, home directory paths,
+  hostnames). The issue is public. Refer to yourself or other
+  contributors only by their GitHub handle. See AGENTS.md §10.

--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -152,6 +152,39 @@ If this fails, stop and report. Never claim an issue on top of a
 divergent local `main` — the branch you create will carry commits
 that do not belong to the issue.
 
+## Step 0.5 — Resolve the agent identity (non-PII)
+
+Every later step that writes the agent's identity to a surface — a
+GitHub comment, a PR body, a branch name, a log — must read from
+**this** resolver, never from `git config --get user.email`. The git
+`user.email` field is designed for commit authoring (often a real
+address); reusing it as a public display handle leaks PII onto issues
+and PR threads. AGENTS.md §10 forbids that leak.
+
+Resolution order (first match wins):
+
+```bash
+# 1. Opt-in repo-scoped alias — lets a dev run several agents from one clone.
+AGENT_ID="$(git config --local --get physa.agent-id 2>/dev/null || true)"
+
+# 2. Zero-config default — the GitHub handle is already public (it's the
+#    value GitHub itself puts on the assignee, labels, commits via noreply).
+if [[ -z "$AGENT_ID" ]]; then
+  AGENT_ID="$(gh api user --jq .login 2>/dev/null || true)"
+fi
+
+# 3. First-run bootstrap — interactive only; no silent fallback to user.email.
+if [[ -z "$AGENT_ID" ]]; then
+  read -rp "Agent display name (stored in .git/config as physa.agent-id): " AGENT_ID
+  [[ -n "$AGENT_ID" ]] || { echo "no identity provided — abort"; exit 1; }
+  git config --local physa.agent-id "$AGENT_ID"
+fi
+```
+
+Do **not** read `git config --get user.email`, `whoami`, `hostname`,
+or `$HOME` for any identity that will be written to a public surface.
+Those strings are PII under AGENTS.md §10.
+
 ## Step 1 — Pre-flight sanity checks
 
 ```bash
@@ -171,10 +204,9 @@ task's diff.
 ## Step 2 — Check for an existing claim by this agent
 
 A crashed / compacted agent that restarts must *resume*, not claim a
-second issue.
+second issue. `$AGENT_ID` was resolved safely in Step 0.5 — reuse it.
 
 ```bash
-AGENT_ID="$(git config --get user.email || echo "$(whoami)@$(hostname)")"
 # Issues I already claimed:
 gh issue list --assignee @me --label status:in-progress --state open
 ```
@@ -237,26 +269,23 @@ Pick the top candidate. Let `N` be its issue number.
 
 ```bash
 N=<top issue number>
-TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-AGENT="$(git config --get user.email || echo "$(whoami)@$(hostname)")"
 
-# (a) Flip labels + assign in one API call each.
+# (a) Flip labels + assign in one API call each. The assignee is the
+#     authoritative lock owner; no free-text claim comment is needed.
 gh issue edit "$N" \
   --add-label status:in-progress \
   --remove-label status:ready \
   --add-assignee "@me"
 
-# (b) Post the claim marker comment.
-gh issue comment "$N" --body "Claimed by \`$AGENT\` at $TS via \`/next\`.
-
-<!-- claim-marker:$AGENT -->"
-
-# (c) DOUBLE-CHECK: re-fetch and confirm we are the sole assignee
-# and the label is set.
+# (b) DOUBLE-CHECK: re-fetch and confirm we are the sole assignee
+#     and the label is set. Compare against the resolver-derived login,
+#     never against $AGENT_ID directly (which may be an opt-in alias).
 sleep 2
+MY_LOGIN="$(gh api user --jq .login)"
 VERDICT="$(gh issue view "$N" --json assignees,labels \
-  --jq '(.assignees | length == 1) and
-        (.assignees[0].login == "<my-gh-login>") and
+  --jq --arg me "$MY_LOGIN" '
+        (.assignees | length == 1) and
+        (.assignees[0].login == $me) and
         ([.labels[].name] | contains(["status:in-progress"]))')"
 
 if [[ "$VERDICT" != "true" ]]; then
@@ -266,6 +295,13 @@ if [[ "$VERDICT" != "true" ]]; then
   # Go back to Step 3, exclude #N, retry.
 fi
 ```
+
+**Why no claim-marker comment.** The (label, assignee) pair is the
+lock; a GitHub issue can hold both atomically. A redundant comment
+adds a public surface that leaks whatever identity string the author
+put in it — exactly the leak §10 forbids. The assignee event in the
+issue timeline already records **who** claimed, and **when**, in a
+structured, auditable way.
 
 **Why double-check**: GitHub's label + assignee are eventually
 consistent across replicas. In the 1–2 s window between our write and
@@ -472,3 +508,8 @@ If the rerun also stalls, treat as 9d and escalate.
 - Do not walk away from a PR you opened. Own it through the first CI
   round; if you cannot stay, call `/abandon` with a clear hand-off
   comment on the PR so the next agent (or human) knows the state.
+- Do not read `git config --get user.email` as an identity source,
+  and do not echo `$HOME`, `whoami`, or `hostname` into any GitHub
+  comment, PR body, or issue body. Those strings are PII under
+  AGENTS.md §10. Use the resolver from Step 0.5 instead — it returns
+  the already-public GitHub login by default.

--- a/.claude/skills/pre-commit-check/SKILL.md
+++ b/.claude/skills/pre-commit-check/SKILL.md
@@ -3,9 +3,9 @@ name: pre-commit-check
 description: >
   Run all physa-db pre-commit gates in one pass — formatting, clippy with
   -D warnings, tests, doc tests, private/ path check, conventional-commit
-  message format, and a secrets scan. Must pass locally before any commit.
-  Runs the CI core gate plus additional pre-commit-only checks such as
-  secrets scanning and commit-message validation.
+  message format, and a secrets + PII scan. Must pass locally before any
+  commit. Runs the CI core gate plus additional pre-commit-only checks
+  such as secrets / PII scanning and commit-message validation.
 when_to_use: >
   "pre-commit", "check before commit", "ready to commit", right before
   staging a change for commit.
@@ -81,9 +81,9 @@ just check-private
 This refuses the commit if any path under `private/` is staged. Never
 bypass with `--no-verify`.
 
-## Gate 6 — Secrets scan
+## Gate 6 — Secrets & PII scan
 
-Run a quick ripgrep for likely-secret patterns over the staged diff:
+Run a ripgrep sweep for likely-secret patterns over the staged diff:
 
 ```bash
 git diff --cached | rg -i '(api[_-]?key|secret|token|password|bearer|private[_-]?key|BEGIN (RSA|OPENSSH|PGP))' || echo "no obvious secrets"
@@ -91,6 +91,67 @@ git diff --cached | rg -i '(api[_-]?key|secret|token|password|bearer|private[_-]
 
 Review every match. A false positive is fine; a true match MUST be
 replaced with an env-var indirection before commit.
+
+Then run the PII sweep (AGENTS.md §10). Two checks:
+
+**Check 6a — email literals in the staged diff.** Any real-address
+email is a hard stop; only GitHub noreply aliases and lines listed in
+`.pii-allowlist` are permitted.
+
+```bash
+# Extract staged additions, strip noreply aliases, match emails,
+# suppress allowlisted literals.
+ALLOWLIST=.pii-allowlist
+ALLOWLIST_ARGS=()
+[[ -f "$ALLOWLIST" ]] && ALLOWLIST_ARGS=(-v -f "$ALLOWLIST")
+
+PII_HITS="$(git diff --cached -U0 \
+  | rg '^\+' \
+  | rg -v '^\+\+\+' \
+  | rg -o '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' \
+  | rg -v '@users\.noreply\.github\.com$' \
+  | (if [[ -f "$ALLOWLIST" ]]; then rg -v -f "$ALLOWLIST"; else cat; fi))"
+
+if [[ -n "$PII_HITS" ]]; then
+  echo "BLOCKED: PII email literals in staged diff:"
+  echo "$PII_HITS"
+  echo "Fix: remove the literal, refer to the GitHub handle, or add a"
+  echo "deliberate allow-line to .pii-allowlist with a comment explaining why."
+  exit 1
+fi
+```
+
+**Check 6b — banned identity source in staged skill bodies.** A
+committed skill file MUST NOT call `git config --get user.email` from
+an executable code block, because the value will later be published
+by whatever public-surface writer the skill feeds. The only allowed
+usage is in documentation text that explicitly forbids the pattern.
+
+```bash
+SKILL_LEAKS="$(git diff --cached --name-only --diff-filter=AM \
+  | rg '\.claude/skills/.*\.md$|\.github/agent-prompts/' \
+  | while read -r f; do
+      [[ -f "$f" ]] || continue
+      # Flag the pattern inside ```bash fences, ignore it in prose.
+      awk '
+        /^```bash/ { in_block = 1; next }
+        /^```/     { in_block = 0; next }
+        in_block && /git config[^#]*user\.email/ { print FILENAME ":" NR ": " $0 }
+      ' "$f"
+    done)"
+
+if [[ -n "$SKILL_LEAKS" ]]; then
+  echo "BLOCKED: skill body reads user.email in an executable block:"
+  echo "$SKILL_LEAKS"
+  echo "Fix: use the resolver chain from AGENTS.md §10 (physa.agent-id"
+  echo "→ gh api user --jq .login → interactive prompt)."
+  exit 1
+fi
+```
+
+`.pii-allowlist` format: one regex per line, `#`-comments allowed.
+Use sparingly — every entry weakens the gate. Typical case: a test
+fixture that intentionally embeds a fake email.
 
 ## Gate 7 — Conventional commit message
 
@@ -136,7 +197,7 @@ Gate                         | Result
 3 Clippy -D warnings         | PASS
 4 Tests                      | PASS
 5 Privacy check              | PASS
-6 Secrets scan               | PASS (0 matches)
+6 Secrets & PII scan         | PASS (0 matches)
 7 Conventional commit        | N/A (no message drafted)
 8 Markdown link integrity    | PASS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,34 @@ Do not silently drop work. Do not force a workaround that compromises §0.
   - Never running commands that would print a cred to the terminal (`echo $SECRET`, `curl -v` with auth headers, `cat .env`, partial-prefix displays via `head -c`). To verify a cred exists, use existence checks only: `[ -n "$KEY" ] && echo OK`.
   - If a cred is accidentally printed in the transcript, flag it to the human immediately — don't hide it.
   - Pre-commit hooks (§13) MUST include a secret-scan gate; treat its failure as a hard stop, never `--no-verify`.
+- **Writing personal information (PII) to any public surface.** Public surfaces include: GitHub issue bodies, issue comments, PR titles, PR bodies, PR comments, review comments, release notes, CHANGELOG entries, commit messages that will be pushed, committed files, and any `gh api --method POST/PATCH` payload. PII includes:
+  - Real-address email (anything not `@users.noreply.github.com`).
+  - Full legal names (first + last). The GitHub handle alone is allowed — that's already public.
+  - Phone numbers, postal addresses, physical locations more precise than country / region.
+  - Absolute filesystem paths containing `/home/<name>/`, `/Users/<name>/`, or hostnames.
+  - `whoami`, `hostname`, MAC addresses, IPs of dev / home machines.
+
+  Identity resolver rule: any skill that needs to write "who did this"
+  on a public surface uses this chain, in order, and never falls
+  through to `git config --get user.email` or `whoami`:
+
+  1. `git config --local --get physa.agent-id` — opt-in repo-scoped
+     alias; lets a dev label multiple concurrent agents.
+  2. `gh api user --jq .login` — the GitHub login; already public.
+  3. Interactive prompt on first run, stored back to
+     `git config --local physa.agent-id`.
+
+  `/next` implements this in Step 0.5; other skills reuse the same
+  chain. Reading `user.email` is forbidden for any path that writes
+  to a public surface — the field is designed for commit authoring
+  (often a real email) and is not a display handle.
+
+  Mechanical enforcement: `/pre-commit-check` Gate 6 fails on any
+  staged email literal except `*@users.noreply.github.com`, and on
+  any staged skill file containing `git config --get user.email`.
+  Treat that gate's failure the same as a secret leak: fix, re-stage,
+  never `--no-verify`.
+
 - Introducing a "shortcut" — a deliberately-suboptimal approach chosen because the better one is harder. See §12.
 
 When in doubt, **ask**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+physa-db keeps its canonical agent contract in **[AGENTS.md](AGENTS.md)** —
+one file, read by Claude Code, Codex, and every other agent. Claude Code
+pulls this `CLAUDE.md` in first; when they disagree, AGENTS.md wins.
+
+Before anything else, read AGENTS.md in full, then skim
+[`.claude/skills/README.md`](.claude/skills/README.md) for the slash
+commands you should prefer over ad-hoc shell.
+
+## The rules you will touch most often
+
+- **§6 — Project tracking.** GitHub Issues are the system of record.
+  Never work off-book. The `/next` skill implements the claim protocol.
+- **§7 — Research protocol.** Anything under `private/` stays private.
+  Public docs are attribution-free.
+- **§10 — No credentials, no PII on public surfaces.** This is the one
+  most likely to bite you. Do **not** read `git config --get user.email`,
+  `whoami`, `hostname`, or `$HOME` paths into any `gh` write (issue
+  comment, PR body, release note, commit pushed to origin). Use the
+  identity resolver defined in §10 — it returns the GitHub handle, which
+  is already public. `/pre-commit-check` Gate 6 enforces this
+  mechanically on every staged diff.
+- **§11, §12, §15 — First principles, no shortcuts, features first.**
+  Skim these before any design work.
+
+## If you are unsure whether something is a public surface
+
+Ask the question the other way: "will this string end up on github.com
+as something a stranger can read?" If yes, it's public; route the
+identity through the resolver and keep personal info out. When in
+doubt, ask the human.


### PR DESCRIPTION
## What

`/next` Step 4 was posting a claim-marker comment containing the value of
`git config --get user.email` on public GitHub issue threads. That field is
the commit-authoring email, often a real address — not a display handle.
The comment on #52 was manually deleted after discovery.

This PR fixes the skill and raises the enforcement bar so a new agent
cannot reintroduce the leak by accident.

## Why

The existing AGENTS.md §10 covered credentials but said nothing about
personal information. An agent reading the rule would not know that
`user.email` was off-limits on a public surface. Mechanical enforcement
was also missing: no gate failed when the skill itself committed a
`git config --get user.email` call.

Closes #56 — refs #52 (the issue whose claim run surfaced the leak).

## How

**Positive replacement — identity resolver chain.** `/next` gains a new
Step 0.5 that resolves the agent identity through, in order:

1. `git config --local --get physa.agent-id` (opt-in alias for devs who run
   several agents in one clone).
2. `gh api user --jq .login` (the already-public GitHub handle, matches the
   assignee GitHub itself records).
3. Interactive prompt on first `/next`, written back to
   `git config --local physa.agent-id`.

`user.email`, `whoami`, `hostname`, and `$HOME` paths are explicitly
forbidden as identity sources for any path that writes to a public
surface.

**Removal of the leak site.** Step 4 drops the claim-marker comment
entirely. The (label `status:in-progress`, assignee `@me`) pair is already
the atomic lock; the free-text comment was redundant and was the only leak
surface. The double-check now compares against the login returned by
`gh api user --jq .login`, not a hard-coded `<my-gh-login>` placeholder.

**Sibling skills annotated.** `/abandon` and `/file-issue` get explicit
"no PII in public bodies" clauses under What-NOT-to-do — both skills post
free-text to public surfaces (issue comments / issue bodies).

**Rule codified in AGENTS.md §10.** A new bullet "No PII on public
surfaces" enumerates the banned surfaces (issue bodies/comments, PR
bodies/comments, release notes, pushed commit messages, committed files,
`gh api --method POST/PATCH` payloads), the banned sources (real-address
email, full legal names, phone, home paths, hostnames, IPs, MAC), and
names the resolver chain. Points at `/pre-commit-check` Gate 6 as the
mechanical enforcer.

**Gate 6 split into 6a + 6b.** 6a scans staged diff additions for email
literals, excluding `@users.noreply.github.com` and anything listed in an
opt-in `.pii-allowlist`. 6b scans staged skill bodies
(`.claude/skills/**/*.md`, `.github/agent-prompts/`) for
`git config … user.email` inside executable ```bash fences — prose
mentions of the banned pattern are ignored. Either hit blocks the
commit; no `--no-verify`.

**CLAUDE.md pointer.** Tools that only look for `CLAUDE.md` now get a
thin redirect into AGENTS.md with §10 called out by name. Keeps
Claude-Code / Codex parity.

## Test plan

- [ ] `just check-private` still passes (no `private/` paths in diff).
- [ ] `grep -rnE 'git config.*user\.email|whoami|hostname' .claude/skills/`
      returns only prose mentions (docs/examples) — no executable-block
      reads. Manually verified on this branch.
- [ ] Gate 6a dry-run on this diff: no real email literals — confirmed.
- [ ] Gate 6b dry-run on this diff: no ```bash block reads `user.email`
      — confirmed.
- [ ] Manual dogfood: a follow-up `/next` run uses the resolver and
      posts **no** claim comment — will be validated on the first
      autonomous-loop run after merge.

## Out of scope

- History rewrite / past-issue scrub. The triggering comment was deleted;
  history cleanup is the user's prerogative and is not automated here.
- Auto-writing the user's `.git/config` `user.email`. The resolver is
  read-only on `user.email`; the opt-in `physa.agent-id` is the only
  local-config write the skill performs, and only after interactive
  confirmation.
- Third-party PII (competitor names, dependency contributor names).
  Those are governed by §7 separately.