### PR TITLE
fix(infra): /next Step 0 prunes all stale agent/* branches, not just [gone]

### DIFF
--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -49,37 +49,65 @@ silently branch off an out-of-date `main` and ship a broken diff.
 git fetch --all --prune --tags
 ```
 
-Then prune local branches whose upstream was deleted AND whose commits
-are already reachable from `origin/main`. `--prune` cleans
-remote-tracking refs but leaves local branches behind; left alone they
-accumulate across every `/next` cycle, clutter `git branch`, and can
-confuse the Step 1 sanity check if one of them matches `agent/*`.
-
-**Safety rule:** a `[gone]` upstream alone is not enough — another
-agent (or a previous self) may have local-only commits that were
-never pushed, or were pushed and then the remote branch was deleted
-for a reason other than merge. Deleting such a branch with `-D`
-silently drops unmerged work. So check reachability first:
+If the current `HEAD` is a strict-subset `agent/*` branch — the
+common "the previous session ended on a merged branch" state — step
+back onto `main` first, so the broader prune that follows can delete
+it. The tree must be clean to do this safely; a dirty tree means
+there is uncommitted work that belongs to the current task and has
+not yet been released, so we stop instead.
 
 ```bash
-git branch --list --format='%(refname:short) %(upstream:track)' \
-  | awk '$2 == "[gone]" {print $1}' \
+CURRENT="$(git branch --show-current)"
+if [[ "$CURRENT" == agent/* ]]; then
+  UNREACHABLE="$(git rev-list --count "$CURRENT" --not origin/main 2>/dev/null || echo 999)"
+  if [[ "$UNREACHABLE" == "0" ]]; then
+    if [[ -n "$(git status --porcelain)" ]]; then
+      echo "HEAD on strict-subset branch '$CURRENT' but tree is dirty — aborting."
+      exit 1
+    fi
+    git switch main
+    git pull --ff-only
+    echo "HEAD rescued: $CURRENT is a strict subset of origin/main, switched to main."
+  fi
+fi
+```
+
+Then prune **every** local `agent/*` branch whose commits are already
+reachable from `origin/main`, regardless of upstream state. This
+catches the three leftover-state families observed in practice:
+
+1. `[gone]` upstream + absorbed by main — the classical case (PR
+   merged, GitHub auto-deleted the remote).
+2. `[gone]` upstream + some divergence — we keep it, user may have
+   local work to rescue.
+3. **No upstream at all** — branch was created by a `/next` that
+   never pushed (abandoned claim, short exploration). The old
+   `[gone]`-only filter missed this forever; the catch-all below
+   handles it.
+
+**Safety rule unchanged**: only delete branches that are **strict
+subsets** of `origin/main` (`git rev-list --count <br> --not
+origin/main` == 0). Branches with any divergence survive the sweep
+and are surfaced for human / original-agent inspection.
+
+```bash
+PRUNED=()
+KEPT=()
+git branch --list 'agent/*' --format='%(refname:short)' \
   | while read -r br; do
-      # Skip if this branch has ANY commit not reachable from origin/main.
-      # That means real work is at risk — leave the branch alone and
-      # surface it for the human / original agent.
+      [[ "$br" == "$(git branch --show-current)" ]] && continue
       UNREACHABLE="$(git rev-list --count "$br" --not origin/main 2>/dev/null || echo 999)"
       if [[ "$UNREACHABLE" == "0" ]]; then
-        git branch -D "$br"
+        git branch -D "$br" >/dev/null && echo "pruned $br (strict subset of origin/main)"
       else
-        echo "skipping $br: $UNREACHABLE commit(s) not on origin/main — inspect manually"
+        echo "kept   $br: $UNREACHABLE commit(s) not on origin/main — inspect manually"
       fi
     done
 ```
 
-Only branches that are **strict subsets** of `origin/main` get deleted
-— those are provably safe (the squash-merge already absorbed their
-content). Branches with any divergence survive the sweep.
+Nothing outside the `agent/*` namespace is touched. Branches the dev
+owns for other workflows (`feature/*`, `wip-*`, personal experiments)
+are invisible to this sweep.
 
 Then sweep **remote** orphan `agent/*` branches. Local pruning above
 only catches branches whose remote was already deleted. The opposite
@@ -151,6 +179,25 @@ fi
 If this fails, stop and report. Never claim an issue on top of a
 divergent local `main` — the branch you create will carry commits
 that do not belong to the issue.
+
+Finally, surface any local stashes — non-destructively. Stashes
+encode in-flight work the skill has no right to drop (the user
+stashed for a reason), but an accumulating stash list is a symptom
+of abandoned branches the earlier sweep may not have caught.
+
+```bash
+STASH_COUNT="$(git stash list | wc -l)"
+if [[ "$STASH_COUNT" -gt 0 ]]; then
+  echo "⚠️ $STASH_COUNT local stash(es) present — inspect with 'git stash list':"
+  git stash list
+fi
+```
+
+The invariant after Step 0 is **mechanical**: a clone that finishes
+a `/next` cycle holds only `main` + optionally the branch of the
+currently claimed issue. No dangling `agent/*` branches, no stale
+`[gone]` entries. If a user runs `/next` twice back-to-back on a
+clean clone, the second run's sweep is a no-op.
 
 ## Step 0.5 — Resolve the agent identity (non-PII)
 
@@ -508,6 +555,11 @@ If the rerun also stalls, treat as 9d and escalate.
 - Do not walk away from a PR you opened. Own it through the first CI
   round; if you cannot stay, call `/abandon` with a clear hand-off
   comment on the PR so the next agent (or human) knows the state.
+- Do not skip Step 0 when resuming a session. It is how the repo
+  self-heals between cycles; skipping it leaves stale `agent/*`
+  branches that accumulate across every run and pollute `git branch`
+  until a human cleans up manually. The sweep is cheap (one
+  `git fetch` + a few `rev-list` per branch) and idempotent.
 - Do not read `git config --get user.email` as an identity source,
   and do not echo `$HOME`, `whoami`, or `hostname` into any GitHub
   comment, PR body, or issue body. Those strings are PII under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,10 @@ When multiple agents work in parallel, GitHub acts as the lock manager. The prot
 
 If you are extending the protocol (e.g. adding a claim TTL override label), update this section, the `next` and `abandon` skills, and the reaper workflow in the same PR.
 
+### 6.2 Clean-repo invariant
+
+After every `/next` run, the developer's clone holds **only** `main` + optionally the branch of the currently claimed issue. No dangling `agent/*` branches (whether from abandoned claims or merged PRs whose remote was auto-deleted), no stale `[gone]` upstreams, no HEAD parked on a merged branch. The Step 0 sweep in `/next` is the enforcer; invoking `/next` twice back-to-back on a clean clone is a no-op. Stashes are surfaced non-destructively but never auto-dropped — they may encode in-flight work no skill has the right to discard.
+
 ---
 
 ## 7. Research protocol (public output, private input)


### PR DESCRIPTION
## What

`/next` Step 0 now self-heals the repo after every cycle, not just when
a branch's remote has been marked `[gone]`. Two common residue states
that previously accumulated are now handled:

1. **Branches never pushed** — abandoned claims or short explorations
   that never got an upstream → the old `[gone]`-only filter missed
   them forever.
2. **Branches whose PR just merged during the same session** — remote
   auto-deleted by GitHub, local tracking ref stale until next fetch.

## Why

`AGENTS.md` §6.2 (new subsection): *"after every `/next` run, the
developer's clone holds only `main` + optionally the currently claimed
branch"*. The end of today's previous session violated this — the
clone ended with two stale `agent/*` branches and HEAD parked on a
merged branch. The founder flagged that as a hard requirement:
*« à la fin du traitement d'une issue le repo du dev reste clean
absolument »*.

Closes #58.

## How

Step 0 gains three pieces:

- **HEAD rescue before the sweep.** If the current branch is a
  strict-subset `agent/*`, tree is clean, switch to main and
  fast-forward first. Dirty tree aborts instead of clobbering
  in-flight work.
- **Catch-all strict-subset sweep** replaces the `[gone]`-only
  filter. Iterates every local `agent/*` branch except the current
  one, deletes those that `rev-list --count <br> --not origin/main`
  reports as 0 (strict subset of main). Divergent branches survive
  and are logged for human inspection.
- **Non-destructive stash surface.** `git stash list` output if any
  stashes exist; we never auto-drop (they may encode in-flight work).

Scope is strictly the `agent/*` namespace. `feature/*`, `wip-*`,
personal experiments are invisible to this sweep.

## Test plan

- [ ] Manual dogfood on this branch: locally, create a throwaway
      `agent/999-test` based on main, switch back to main, run the new
      Step 0 loop manually, confirm `agent/999-test` is pruned. Record
      the before/after in a comment on the PR.
- [ ] Gate 6a (PII email scan) self-check on this diff — clean,
      confirmed.
- [ ] Gate 6b (user.email in bash block) self-check — clean, confirmed.
- [ ] Idempotence: running the sweep twice on a fully-clean clone is a
      no-op (new invariant, explicitly called out in §6.2).

## Out of scope

- Auto-dropping stashes (destructive on user state — surface only).
- Pruning non-agent branches (strict namespace ownership).
- A separate `/tidy` skill (strengthening Step 0 covers the
  invariant cheaper).
- Reaper-side changes (`reap-stale-claims.yml` — different scope,
  handles abandoned *claims* not stale branches).