### PR TITLE
docs: stop advertising /onboard as a re-hydration command

### DIFF
--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: onboard
 description: >
-  Mandatory first read for any agent joining physa-db. Surfaces the two-pillar
-  positioning, the rules (§§7, 11, 12, 15), the causal chain
+  Mandatory first read for any agent arriving cold on this clone. Surfaces
+  the two-pillar positioning, the rules (§§7, 11, 12, 15), the causal chain
   (positioning → workloads → features → ADRs → code), and the reading order.
-  Invoke when a new agent session starts, or when re-hydrating context after
-  compaction, or when the user asks "where should I start?".
+  Invoke once at the start of a fresh clone (or when the user asks "where
+  do I start?"). If an agent mid-session loses specific rules, re-read the
+  relevant AGENTS.md section directly — do not re-run the full onboarding.
 when_to_use: >
   "onboard", "how does this project work", "where do I start", "what are the
-  rules", new agent session on physa-db, re-orientation after compaction.
+  rules", fresh clone of physa-db with no prior session context.
 argument-hint: ""
 user-invocable: true
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,7 +403,7 @@ Invocation syntax differs by agent. Claude Code exposes these as slash commands 
 
 | Skill | Rule encoded | When to call |
 |-------|--------------|--------------|
-| `onboard` | §§0, 7, 11, 12, 15 | Start of every new agent session, or after compaction |
+| `onboard` | §§0, 7, 11, 12, 15 | First run on a fresh clone (a guided tour of the rules — not a re-hydration command; an agent mid-session that lost context should re-read the relevant AGENTS.md section directly) |
 | `plan-feature <desc>` | §§11, 15 | Before any code — locks the FM row, workload anchor, derivation, AC |
 | `write-adr <NNNN> <title>` | §§11, 15 | When `plan-feature` concluded an ADR is needed |
 | `research-competitor <CODENAME> <real-name>` | §7, ADR-0006 | Any competitor profile — forces codename + private input + public delta |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ claude .            # or: codex, cursor, …
 
 Then, inside your agent:
 
-1. **`/onboard`** — installs the pinned toolchain (`mise install`), verifies `gh auth`, reads the rules and pillars, lists ready tasks. Run it first in every fresh session and after any context-compaction.
+1. **`/onboard`** — installs the pinned toolchain (`mise install`), verifies `gh auth`, reads the rules and pillars, lists ready tasks. Run it once per fresh clone; subsequent sessions enter the loop directly at `/next`. (If an agent mid-session loses a specific rule, it should re-read the relevant `AGENTS.md` section from disk — not re-run the full onboarding.)
 2. **`/next`** — claims the next `status:ready` GitHub Issue atomically, creates the `agent/<n>-<slug>` branch, and invokes `/plan-feature` if the issue has no plan yet.
 
 After that, you're inside the dev loop.
@@ -90,7 +90,7 @@ The skills catalog organised by *when to use*, not by tier. Every skill lives un
 | CI red after push (pre-existing rot, not your diff) | File a follow-up issue via `/file-issue`, add a surgical exclusion in the config that owns it (e.g. `lychee.toml`), reference the follow-up issue in the exclusion comment. Keeps your PR mergeable without papering over the root cause. |
 | You are stuck (context / dependency / environment) | `/abandon blocked "<reason>"` — releases the claim back to the pool. Don't walk away silently. |
 | Session ended mid-task, claim still yours | New session: `/onboard` then `/next`. The skill sees your existing claim and resumes instead of claiming a new issue. |
-| Context lost to compaction | `/onboard` again — it's idempotent and designed to re-hydrate. |
+| Specific rule forgotten mid-session | Re-read the relevant `AGENTS.md` section from disk. The full `/onboard` guided tour is for cold-start agents, not for re-hydration. |
 | You left a dormant claim > 24 h | [`reap-stale-claims.yml`](.github/workflows/reap-stale-claims.yml) reverts it to `status:ready` automatically. No cleanup needed from you. |
 
 ## Issue lifecycle

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ claude .            # or: codex, cursor, …
 
 Then, inside your agent:
 
-1. **`/onboard`** — installs the pinned toolchain (`mise install`), verifies `gh auth`, reads rules + pillars, lists ready tasks. Run this first in every fresh session (and after any context-compaction). *(Auto-install behaviours are tracked for implementation — see [#52](https://github.com/mroche14/physa-db/issues/52) and the follow-up `/onboard` enrichment issue.)*
+1. **`/onboard`** — installs the pinned toolchain (`mise install`), verifies `gh auth`, reads rules + pillars, lists ready tasks. Run this once per fresh clone; subsequent sessions enter the loop directly at `/next`. *(Auto-install behaviours are tracked for implementation — see [#52](https://github.com/mroche14/physa-db/issues/52) and the follow-up `/onboard` enrichment issue.)*
 2. **`/next`** — claims the next `status:ready` GitHub Issue atomically, creates the `agent/<n>-<slug>` branch, and invokes `/plan-feature` if the issue has no plan yet.
 
 That's the entry gate. The full loop (`/plan-feature` → code → `/pre-commit-check` → commit → push + PR → `/wait-ci`) plus error-recovery paths and the skills-by-moment reference live in [`CONTRIBUTING.md`](./CONTRIBUTING.md). The complete agent contract — rules §§1–15, claim protocol §6.1, skills catalog §16 — lives in [`AGENTS.md`](./AGENTS.md).
@@ -145,7 +145,7 @@ Two paths, one command each as the entry point:
 - **Contributor path** — you have an agent (Claude Code, Codex, Cursor, …) and tokens to burn. You run `/onboard` once per clone, then `/next` on repeat. The agent decides everything else: whether the claimed issue needs `/plan-feature` first, whether a bug surfaced mid-work warrants `/file-issue`, whether to `/abandon blocked` when stuck. You don't pick skills — the agent does. Ideal for external contributors who want to ship without reading the full contract.
 - **Maintainer path** — directional work that stays human-owned: editing the [feature matrix](./docs/requirements/feature-matrix.md) (the single-source list of what physa-db will do, tier-scored, that every issue links back to), promoting Architecture Decision Records ([ADRs](./docs/architecture/adr/)) from `Proposed` to `Accepted`, governing the label/milestone taxonomy, and cutting releases. These are not automatable because they set the direction the agents then execute against.
 
-The diagram below shows both paths in one view. Maintainers curate the issue queue on the left; contributors (or their agents) consume it on the right. `/onboard` is a **one-shot** bootstrap — run once per clone (or after a context compaction) to load the rules and positioning into the agent — and after that every session enters the loop directly at `/next`. Dotted edges are escape hatches the agent takes autonomously when the conditions match, including `/file-issue`, which feeds a newly-surfaced bug back into the same queue the loop consumes.
+The diagram below shows both paths in one view. Maintainers curate the issue queue on the left; contributors (or their agents) consume it on the right. `/onboard` is a **one-shot** bootstrap — run once per clone to load the rules and positioning into the agent — and after that every session enters the loop directly at `/next`. Dotted edges are escape hatches the agent takes autonomously when the conditions match, including `/file-issue`, which feeds a newly-surfaced bug back into the same queue the loop consumes.
 
 ```mermaid
 flowchart TD
@@ -158,7 +158,7 @@ flowchart TD
 
     m2 --> next
 
-    first([first time on this clone,<br/>or after compaction]) --> onboard[/onboard/]
+    first([first time on this clone]) --> onboard[/onboard/]
     onboard --> next[/next/]
     repeat([any subsequent session]) --> next
 


### PR DESCRIPTION
## What

Closes #66. \`/onboard\` was advertised (in five different places) as
a skill to re-run \"after compaction\" — when the agent's context
window has been compressed. That framing was wrong in two ways:

1. **Technically.** An agent that loses a specific rule mid-session
   should re-read the relevant \`AGENTS.md\` section from disk, not
   re-run a guided tour of the whole project. \`/onboard\` is for
   a truly cold agent; \`AGENTS.md\` on disk is for everything else.
2. **For human readers.** \"Compaction\" is agent-harness jargon
   (Claude Code / Codex window-management). A README shouldn't
   require that knowledge to be readable.

## Why

Asked by the founder during #65 review: *« wtf is after compaction »*.
He was right — the whole framing was muddying the pitch (\"contributor
= just /next\") with an edge case that didn't belong in the contract.

## How

Five locations updated:

| File | Change |
|------|--------|
| \`.claude/skills/onboard/SKILL.md\` | description + when_to_use now describe a first-clone guided tour; tells mid-session agents to re-read AGENTS.md directly |
| \`AGENTS.md\` §16 skills table | onboard row re-worded |
| \`CONTRIBUTING.md\` step 1 + troubleshooting | \"once per fresh clone\"; troubleshooting row now points at AGENTS.md re-read instead of /onboard |
| \`README.md\` quick-start step 1 | \"Run this once per fresh clone; subsequent sessions enter the loop directly at \`/next\`\" |
| \`README.md\` dev-loop diagram | entry node label is now just \"first time on this clone\" — the compaction edge case is gone |

The two remaining \"compacted\" references (in \`/next\` Step 2 and
AGENTS §6.1 reaper) describe a different concept — the claim
protocol's resilience when an agent crashes or is compacted
mid-claim — and are left intact. They don't tell anyone to re-run
\`/onboard\`.

## Test plan

- [x] \`grep -rn 'compaction\\|compacted'\` in the changed files
      returns only the two legitimate claim-protocol references.
- [ ] docs-link-check passes.
- [ ] Semantic unchanged: \`/onboard\` still runs its full
      guided-tour body on first invocation — only the when-to-call
      framing changed.

## Out of scope

- Explaining window compaction or context management anywhere in
  the docs. It's an agent-harness concern, not a project concern.
- Rewriting the \`/onboard\` skill body (the content of the tour is
  correct; only its triggers were wrong).