### PR TITLE
docs(readme): show the "/" prefix on Mermaid skill nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,28 +158,28 @@ flowchart TD
 
     m2 --> next
 
-    first([first time on this clone]) --> onboard[/onboard/]
-    onboard --> next[/next/]
+    first([first time on this clone]) --> onboard[/"/onboard"/]
+    onboard --> next[/"/next"/]
     repeat([any subsequent session]) --> next
 
     next -->|acceptance criteria<br/>present in issue| code[write code<br/>run-stress / run-bench as needed]
-    next -->|acceptance criteria<br/>missing| plan[/plan-feature/]
+    next -->|acceptance criteria<br/>missing| plan[/"/plan-feature"/]
     plan --> code
 
-    code --> precheck[/pre-commit-check/]
+    code --> precheck[/"/pre-commit-check"/]
     precheck -->|fail| code
     precheck -->|pass| push[commit + push<br/>gh pr create]
-    push --> waitci[/wait-ci/]
+    push --> waitci[/"/wait-ci"/]
 
     waitci -->|✅ all green| review([PR → status:needs-review])
     waitci -->|⏳ timeout| resume([surface + resume later])
     waitci -->|❌ CI fails| retries{≤ 3 fix<br/>iterations?}
 
     retries -->|yes| code
-    retries -->|no| nh[/abandon → agent:needs-human/]
+    retries -->|no| nh[/"/abandon → agent:needs-human"/]
 
-    code -. stuck / blocker .-> blocked[/abandon → status:blocked/]
-    code -. new bug surfaced .-> fileissue[/file-issue/]
+    code -. stuck / blocker .-> blocked[/"/abandon → status:blocked"/]
+    code -. new bug surfaced .-> fileissue[/"/file-issue"/]
     fileissue -.-> m2
 
     classDef skill fill:#e8f0ff,stroke:#4a6fa5,color:#1a2a3a


### PR DESCRIPTION
## What

Closes #68. Skill nodes in the dev-loop Mermaid rendered as
\`onboard\`, \`next\`, \`plan-feature\`, etc. — without the \`/\`
prefix that signals "this is a slash command". A reader looking at
the diagram alone couldn't tell commands from activities.

Labels now use quoted strings inside the parallelogram shape so the
literal \`/\` appears in each skill node: \`/onboard\`, \`/next\`,
\`/plan-feature\`, \`/pre-commit-check\`, \`/wait-ci\`,
\`/file-issue\`, and both \`/abandon → …\` nodes.

## Mermaid syntax note

The parallelogram shape \`[/text/]\` uses \`/\` as shape delimiters.
To include a literal \`/\` in the label, the content must be quoted:
\`[/"/next"/]\`. Outer \`[/ … /]\` is still the shape; the
\`"…"\` is the quoted label content, which can contain any chars
including \`/\`.

## Test plan

- [ ] docs-link-check (lychee) passes.
- [ ] Manual smoke on github.com after merge: every skill node
      renders with its leading \`/\`, and the parallelogram shape
      is preserved.

## Out of scope

- Structural / semantic changes to the diagram — this PR is
  label-text only.
- Adding \`/\` prefixes outside the Mermaid — inline prose already
  uses \`/onboard\`, \`/next\`, etc. consistently.