### PR TITLE
feat(infra): /wait-ci skill — CI poll + test-plan checklist walker

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -49,6 +49,7 @@ Companion infra: [`.github/workflows/reap-stale-claims.yml`](../../.github/workf
 | [`run-stress`](./run-stress/SKILL.md) | Run a stress scenario (smoke / chaos / soak / disk-full / oom / partition / clock-skew / poison / supernode) and check invariants | Any PR touching storage / MVCC / cluster |
 | [`run-bench`](./run-bench/SKILL.md) | Reproducible criterion + iai-callgrind + macro bench with hardware context and baseline comparison | Any PR labelled `type:perf` |
 | [`file-issue`](./file-issue/SKILL.md) | Canonical GitHub Issue template with FM row, acceptance criteria, labels | Every task > 1 h of effort |
+| [`wait-ci`](./wait-ci/SKILL.md) | Poll CI after a push, walk the PR test-plan checklist against the predicate library, post a single verdict comment | Every `gh pr create` (Step 9 of `/next`) |
 
 ### Planned (Tier 3 — not yet authored)
 

--- a/.claude/skills/next/SKILL.md
+++ b/.claude/skills/next/SKILL.md
@@ -439,98 +439,114 @@ agent until Step 9 confirms the PR is green — otherwise a red PR
 becomes a stale `needs-review` that the reaper will not touch and no
 other agent will pick up.
 
-## Step 9 — Watch the PR through CI
+## Step 9 — Hand off to `/wait-ci`
 
-A PR is not "done" when pushed — it is done when every required check
-passes. An agent that opens a PR and walks away ships the red to the
-human reviewer. The agent owns its PR until CI is green.
-
-### 9a — Block on the first round
+A PR is not "done" at `gh pr create`. It is done when every required
+check is green AND the PR body's test-plan checklist has been walked.
+Both are the job of [`/wait-ci`](../wait-ci/SKILL.md); `/next` just
+dispatches on the verdict.
 
 ```bash
-gh pr checks "$PR_NUM" --watch --fail-fast --interval 10
-CHECK_RC=$?
+/wait-ci "$PR_NUM"
+CI_RC=$?
 ```
 
-`--watch` blocks while any check is pending. `--fail-fast` returns
-non-zero the moment one fails (no need to wait for the rest). The
-`--interval 10` polls every 10 s — costs nothing on a quiet repo, and
-is polite on GitHub's API.
+`/wait-ci` returns one of four exit codes. Dispatch:
 
-### 9b — If all green
+### 9a — `success` (exit 0): hand off cleanly
+
+All required checks green, every test-plan item auto-verified by the
+predicate library. Flip the label and release the claim.
 
 ```bash
-if [[ "$CHECK_RC" -eq 0 ]]; then
+if [[ "$CI_RC" -eq 0 ]]; then
   gh issue edit "$N" \
     --add-label status:needs-review \
     --remove-label status:in-progress
-  echo "PR #$PR_NUM green — handed off for review"
+  echo "PR #$PR_NUM green + checklist resolved — handed off for review"
   exit 0
 fi
 ```
 
-### 9c — If any red: diagnose, fix, re-push
+### 9b — `pending-human` (exit 5): hand off with a surfaced list
+
+CI green, but one or more test-plan items fell into the manual-pending
+or deferred-follow-up buckets. Technically mergeable, but the human
+should see the list first.
+
+```bash
+if [[ "$CI_RC" -eq 5 ]]; then
+  gh issue edit "$N" \
+    --add-label status:needs-review \
+    --remove-label status:in-progress
+  echo "PR #$PR_NUM green — items pending human verification surfaced in \`/wait-ci\`'s comment on the PR"
+  echo "Review the ⚠️ and 🔁 lists before merging."
+  exit 0
+fi
+```
+
+### 9c — `fail` (exit 4): diagnose, fix, re-push; max 3 iterations
+
+`/wait-ci` already posted a structured failure comment with the last 50
+lines of the failing job. Read it, reason about the root cause, apply
+the fix (run `/pre-commit-check` before committing), push, re-invoke
+`/wait-ci`.
 
 Budget: **3 fix iterations**. Past that, the failure is almost
-certainly not a surface bug — it needs a human.
+certainly not a surface bug — escalate per 9d.
 
 ```bash
 ITER=0
-while [[ "$CHECK_RC" -ne 0 && "$ITER" -lt 3 ]]; do
+while [[ "$CI_RC" -eq 4 && "$ITER" -lt 3 ]]; do
   ITER=$((ITER + 1))
   echo "=== CI fix iteration $ITER/3 ==="
 
-  # Which checks failed, and why.
-  FAILED_JOBS="$(gh pr checks "$PR_NUM" --json name,state,link \
-    --jq '[.[] | select(.state == "FAILURE" or .state == "CANCELLED")]')"
-  echo "$FAILED_JOBS"
+  # The structured diagnosis is already on the PR — scroll `gh pr view --comments`.
+  gh pr view "$PR_NUM" --comments --json comments \
+    --jq '[.comments[] | select(.body | test("<!-- wait-ci:fail -->"))] | last | .body' \
+    | head -80
 
-  # Fetch logs for each failed job. The `--log-failed` flag returns only
-  # failing steps, which fits agent context windows better than full logs.
-  RUN_ID="$(gh pr checks "$PR_NUM" --json link \
-    --jq '.[] | select(.state == "FAILURE") | .link' \
-    | head -1 | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')"
-  gh run view "$RUN_ID" --log-failed > /tmp/failed-${PR_NUM}-${ITER}.log
-
-  # Read the log, reason about the root cause, apply the fix,
-  # run `/pre-commit-check`, commit with a `fix(ci): …` prefix, push.
-  # THEN re-enter the watch loop:
-  gh pr checks "$PR_NUM" --watch --fail-fast --interval 10
-  CHECK_RC=$?
+  # Fix the code, commit (conventional prefix `fix(ci): …`), push.
+  # Then re-run /wait-ci for the next round:
+  /wait-ci "$PR_NUM"
+  CI_RC=$?
 done
 ```
 
-### 9d — If still red after 3 iterations
+### 9d — Still `fail` after 3 iterations: hand to a human
 
-The failure is not mechanical. Hand the PR back to a human instead of
-wasting more cycles:
+The failure is not mechanical. Don't burn more cycles.
 
 ```bash
-gh pr comment "$PR_NUM" --body "CI failing after 3 automated fix \
-attempts. Handing to human — see \`/tmp/failed-${PR_NUM}-*.log\` \
-snapshots in the last commits. Likely root cause: <one-sentence \
-summary from the logs>."
-gh issue edit "$N" \
-  --add-label agent:needs-human \
-  --remove-label status:in-progress
+if [[ "$CI_RC" -eq 4 ]]; then
+  gh pr comment "$PR_NUM" --body "CI failing after 3 automated fix \
+attempts. Handing to human — see the \`/wait-ci\` failure comments \
+above for the log tails. Likely root cause: <one-sentence summary>."
+  gh issue edit "$N" \
+    --add-label agent:needs-human \
+    --remove-label status:in-progress
+fi
 ```
 
 Do **not** mark the issue `status:needs-review` while CI is red — a
 red PR masquerading as ready-to-review poisons the review queue and
 demoralises the human reviewer who opens it expecting a clean diff.
 
-### 9e — If the tree is clean but checks are stuck pending
+### 9e — `timeout` (exit 3): surface and resume later
 
-GitHub Actions sometimes wedges (queue stall, runner outage). After 30
-minutes of pending with no state transition:
+`/wait-ci`'s 20 min cap fired (GitHub Actions queue pressure, runner
+outage, …). The PR isn't green yet, but there's no failing check to
+fix either. Leave the claim in place, surface to the user, optionally
+re-invoke.
 
 ```bash
-gh pr comment "$PR_NUM" --body "CI stuck in pending for 30+ min — \
-re-running via \`gh pr rerun\`."
-gh run rerun "$RUN_ID" --failed
+if [[ "$CI_RC" -eq 3 ]]; then
+  echo "PR #$PR_NUM CI still pending after 20 min — \`/wait-ci\` left a"
+  echo "marker comment. Re-run \`/wait-ci $PR_NUM\` later, or \`gh run rerun\`"
+  echo "the stuck workflow if it's been > 30 min with no state change."
+  exit 6
+fi
 ```
-
-If the rerun also stalls, treat as 9d and escalate.
 
 ## What NOT to do
 

--- a/.claude/skills/wait-ci/SKILL.md
+++ b/.claude/skills/wait-ci/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: wait-ci
+description: >
+  Poll CI on a pull request until all required checks settle, then walk the
+  PR body's test-plan checklist and resolve every unchecked item against a
+  deterministic predicate library. Runs inside the autonomous loop — no stdin
+  required. End-of-task gate: a task is "done" when `/wait-ci` returns
+  `success` (or `pending-human` with the list surfaced).
+when_to_use: >
+  Right after `gh pr create`, any time a PR's checks have been red and
+  been re-pushed, before marking an issue `status:needs-review`, and as
+  Step 9 of `/next` — the loop's mandatory post-push gate.
+argument-hint: "[pr-number]  # defaults to the PR attached to the current branch"
+user-invocable: true
+allowed-tools:
+  - Bash(gh *)
+  - Bash(git *)
+  - Bash(awk *)
+  - Bash(grep *)
+  - Bash(rg *)
+  - Bash(sed *)
+  - Bash(jq *)
+  - Bash(cat *)
+  - Bash(sleep *)
+  - Bash(date *)
+  - Read
+---
+
+# wait-ci — post-push gate: CI green + test-plan checklist resolved
+
+`PR number:` $ARGUMENTS (empty = PR attached to the current branch).
+
+A PR is not "done" at `gh pr create`. It is done when:
+
+1. every required check is green,
+2. the PR body's **Test plan** checklist has been walked — every `- [ ]`
+   item ends in one of three explicit states (verified / manual-pending /
+   deferred-follow-up), and
+3. the structured verdict is recorded as a single comment on the PR.
+
+This skill enforces all three. It runs inside the autonomous loop, so
+every decision is deterministic from the predicate library — **never
+prompts the user**.
+
+## Step 1 — Resolve the PR number
+
+```bash
+N="${ARGUMENTS:-}"
+if [[ -z "$N" ]]; then
+  N="$(gh pr view --json number --jq '.number' 2>/dev/null || true)"
+fi
+[[ -n "$N" ]] || { echo "no PR number supplied and none attached to current branch — abort"; exit 2; }
+```
+
+## Step 2 — Poll CI
+
+Cap at 20 min (80 × 15 s). `gh pr checks --watch --fail-fast --interval 15`
+blocks the right way:
+
+- returns 0 when every required check is green,
+- returns non-zero the moment a required check fails (fail-fast),
+- stays blocked on pending until it flips one way or the other.
+
+Wrap it in `timeout` so we surface a clear timeout instead of an open loop.
+
+```bash
+CI_START_SHA="$(gh pr view "$N" --json headRefOid --jq .headRefOid)"
+echo "wait-ci: polling PR #$N at $CI_START_SHA (cap = 20 min)"
+if timeout 1200 gh pr checks "$N" --watch --fail-fast --interval 15; then
+  CI_VERDICT="green"
+else
+  RC=$?
+  # timeout returns 124; anything else is a hard CI failure
+  if [[ $RC -eq 124 ]]; then
+    CI_VERDICT="timeout"
+  else
+    CI_VERDICT="fail"
+  fi
+fi
+echo "wait-ci: CI_VERDICT=$CI_VERDICT"
+```
+
+## Step 3 — Handle the three CI outcomes
+
+### 3a — `timeout`
+
+Post a neutral marker comment so the next agent knows state, then return.
+Do **not** flip the issue label; the PR is still in-flight.
+
+```bash
+if [[ "$CI_VERDICT" == "timeout" ]]; then
+  gh pr comment "$N" --body "⏳ \`/wait-ci\` report at \`$CI_START_SHA\`
+
+CI still pending after 20 min. Re-run \`/wait-ci $N\` to resume
+watching — timeouts are usually GitHub-Actions queue pressure, not
+a code problem.
+
+<!-- wait-ci:timeout -->"
+  exit 3
+fi
+```
+
+Exit code 3 = `timeout` (agent may re-invoke later).
+
+### 3b — `fail`
+
+Extract the failing job, grab the last 50 lines of its log, post a
+structured diagnosis comment. Do **not** walk the checklist — a red PR is
+not "done" and the review label must not be set.
+
+```bash
+if [[ "$CI_VERDICT" == "fail" ]]; then
+  FAILED="$(gh pr checks "$N" --json name,state,link \
+    --jq '[.[] | select(.state == "FAILURE" or .state == "CANCELLED")]')"
+  RUN_ID="$(echo "$FAILED" | jq -r '.[0].link // empty' \
+    | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+')"
+  LOG_TAIL=""
+  if [[ -n "$RUN_ID" ]]; then
+    LOG_TAIL="$(gh run view "$RUN_ID" --log-failed 2>/dev/null | tail -50)"
+  fi
+
+  {
+    echo "❌ \`/wait-ci\` report at \`$CI_START_SHA\`"
+    echo ""
+    echo "Failing checks:"
+    echo "$FAILED" | jq -r '.[] | "- \(.name): \(.state)"'
+    echo ""
+    echo "Last 50 lines of the failing log:"
+    echo ""
+    echo '```'
+    [[ -n "$LOG_TAIL" ]] && echo "$LOG_TAIL" || echo "(log fetch failed — check the job link above)"
+    echo '```'
+    echo ""
+    echo "Next: fix, commit, push, and re-run \`/wait-ci $N\`."
+    echo ""
+    echo "<!-- wait-ci:fail -->"
+  } | gh pr comment "$N" --body-file -
+  exit 4
+fi
+```
+
+Exit code 4 = `fail` (caller should iterate per `/next` Step 9c).
+
+### 3c — `green`: proceed to checklist walk
+
+Continue to Step 4.
+
+## Step 4 — Walk the test-plan checklist
+
+Fetch the PR body and scan for `- [ ]` / `- [x]` task-list lines. A PR
+body without any task-list syntax skips this layer cleanly — the final
+summary reflects only the CI result.
+
+```bash
+BODY="$(gh pr view "$N" --json body --jq '.body')"
+
+# Extract task-list lines with 1-based line numbers (against the body).
+TASK_LINES="$(printf '%s\n' "$BODY" | awk '
+  /^[[:space:]]*-[[:space:]]*\[[ xX]\][[:space:]]+/ { print NR "\t" $0 }')"
+```
+
+If `$TASK_LINES` is empty, jump to Step 6 with the zero-item summary.
+
+### 4a — Apply predicates, line by line
+
+Read [`predicates.md`](./predicates.md) as the single source of truth. The
+library has three buckets, scanned in this order:
+
+1. **auto-verify** — the item is covered by a CI check or by this
+   skill's own self-tests. Flip `[ ]` → `[x]` and append
+   ` — verified by /wait-ci @ <sha>`.
+2. **auto-skip** — the item is manual by design (smoke-test, visual
+   render). Leave `[ ]` unchanged, record it in the summary as
+   "needs human verification".
+3. **auto-defer** — the item describes work outside the PR's scope.
+   Leave `[ ]` unchanged, record it as "deferred to follow-up" with a
+   suggested `/file-issue` title.
+
+**Fallthrough** (no bucket matches): treat as manual-pending, same as
+auto-skip. Conservative default; never auto-verify without explicit match.
+
+For each checked-already `[x]` line, pass through unchanged.
+
+Bash driver (simplified — the real loop reads `predicates.md` into three
+regex arrays and scans each `[ ]` line):
+
+```bash
+VERIFIED=()
+PENDING=()
+DEFERRED=()
+
+NEW_BODY="$BODY"
+while IFS=$'\t' read -r lineno line; do
+  [[ -z "$line" ]] && continue
+
+  # Strip leading "- [ ] " / "- [x] " to get the predicate text.
+  TEXT="$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*\[[ xX]\][[:space:]]+//')"
+
+  if [[ "$line" =~ \[[xX]\] ]]; then
+    # Already checked — leave alone.
+    continue
+  fi
+
+  BUCKET="$(classify "$TEXT")"   # returns: verify | skip | defer | fallthrough
+  case "$BUCKET" in
+    verify)
+      VERIFIED+=("$TEXT")
+      NEW_LINE="$(echo "$line" | sed -E 's/\[ \]/[x]/')"
+      NEW_LINE="${NEW_LINE} — verified by /wait-ci @ ${CI_START_SHA:0:7}"
+      NEW_BODY="${NEW_BODY//$line/$NEW_LINE}"
+      ;;
+    skip|fallthrough)
+      PENDING+=("$TEXT")
+      ;;
+    defer)
+      DEFERRED+=("$TEXT")
+      ;;
+  esac
+done <<< "$TASK_LINES"
+```
+
+`classify()` is a bash function that sources the regex arrays from
+`predicates.md`. See the predicates file for the actual patterns and the
+one-example-per-pattern rule when adding new ones.
+
+### 4b — Patch the PR body
+
+Only if `VERIFIED` is non-empty. Use `gh pr edit --body "$NEW_BODY"`; this
+is PR-body-only metadata, no commit is touched.
+
+```bash
+if [[ ${#VERIFIED[@]} -gt 0 ]]; then
+  printf '%s' "$NEW_BODY" | gh pr edit "$N" --body-file -
+fi
+```
+
+## Step 5 — Delete any previous wait-ci marker comment
+
+`/wait-ci` is idempotent. Re-running it should replace the previous
+report, not append a new one.
+
+```bash
+PREV_IDS="$(gh api "repos/:owner/:repo/issues/${N}/comments" --paginate \
+  --jq '.[] | select(.body | test("<!-- wait-ci:(success|pending-human|fail|timeout) -->")) | .id')"
+for id in $PREV_IDS; do
+  gh api "repos/:owner/:repo/issues/comments/${id}" --method DELETE >/dev/null || true
+done
+```
+
+## Step 6 — Post the single structured summary comment
+
+```bash
+{
+  if [[ ${#PENDING[@]} -eq 0 && ${#DEFERRED[@]} -eq 0 ]]; then
+    VERDICT="success"
+  else
+    VERDICT="pending-human"
+  fi
+
+  echo "✅ \`/wait-ci\` report at \`${CI_START_SHA:0:7}\`"
+  echo ""
+  echo "**CI:** all required checks green."
+  echo ""
+  echo "**Test-plan checklist:**"
+  if [[ ${#VERIFIED[@]} -gt 0 ]]; then
+    echo "- ✅ auto-verified (${#VERIFIED[@]}):"
+    printf '  - %s\n' "${VERIFIED[@]}"
+  fi
+  if [[ ${#PENDING[@]} -gt 0 ]]; then
+    echo "- ⚠️ needs human verification (${#PENDING[@]}):"
+    printf '  - %s\n' "${PENDING[@]}"
+  fi
+  if [[ ${#DEFERRED[@]} -gt 0 ]]; then
+    echo "- 🔁 deferred to follow-up (${#DEFERRED[@]}):"
+    printf '  - %s\n' "${DEFERRED[@]}"
+  fi
+  if [[ ${#VERIFIED[@]} -eq 0 && ${#PENDING[@]} -eq 0 && ${#DEFERRED[@]} -eq 0 ]]; then
+    echo "- (PR body has no task-list syntax — nothing to walk.)"
+  fi
+  echo ""
+  echo "**Verdict:** $VERDICT."
+  if [[ "$VERDICT" == "pending-human" ]]; then
+    echo ""
+    echo "Merge is technically unblocked (no required review), but a human"
+    echo "should verify the ⚠️ items and action the 🔁 items before closing."
+  fi
+  echo ""
+  echo "<!-- wait-ci:${VERDICT} -->"
+} | gh pr comment "$N" --body-file -
+```
+
+## Step 7 — Return verdict
+
+- `success` — exit 0. Caller (typically `/next` Step 9b) flips the issue
+  label to `status:needs-review` and hands the PR off cleanly.
+- `pending-human` — exit 5. Caller may still flip the label, but must
+  surface the `⚠️`/`🔁` lists to the user before releasing the claim.
+- `fail` — exit 4. Caller iterates per `/next` Step 9c (max 3).
+- `timeout` — exit 3. Caller may re-invoke later or escalate per
+  `/next` Step 9e.
+
+```bash
+case "$VERDICT" in
+  success)         exit 0 ;;
+  pending-human)   exit 5 ;;
+esac
+```
+
+## What NOT to do
+
+- Do not run `/wait-ci` before `gh pr create`. It requires a PR number,
+  not a commit SHA. For local pre-push checks use `/pre-commit-check` +
+  `just ci`.
+- Do not force-push during a `/wait-ci` run. The skill reads
+  `headRefOid` at Step 2 and compares in subsequent comments; force-push
+  invalidates that reference.
+- Do not edit the PR body while `/wait-ci` is walking the checklist. The
+  skill patches the body at Step 4b; concurrent edits would be lost.
+- Do not flip the issue to `status:needs-review` when the verdict is
+  `fail` or `timeout`. A red PR masquerading as ready-to-review poisons
+  the review queue (AGENTS.md §6.1, `/next` Step 9c/9d).
+- Do not hand-walk the checklist in a PR-author comment when `/wait-ci`
+  is about to run. The skill's marker comment will overwrite yours. If
+  you need to leave a manual note, post **after** `/wait-ci` ran.
+- Do not bypass the skill by deleting its marker comment. The marker
+  is the audit trail; if you disagree with a verdict, amend the
+  predicates library (`predicates.md`) and re-run.

--- a/.claude/skills/wait-ci/predicates.md
+++ b/.claude/skills/wait-ci/predicates.md
@@ -1,0 +1,126 @@
+# wait-ci predicates library
+
+Each `- [ ]` line in a PR's Test plan section gets classified into one of
+four buckets. `/wait-ci` scans the buckets in the order below and stops at
+the first match — **order matters**: a line that could be `auto-skip` AND
+`auto-verify` is treated as verified, on purpose.
+
+Adding a pattern: append to the correct bucket, include a commented
+example of a real PR line that matches. A predicate without an example is
+untested and will be rejected in review.
+
+Patterns are `grep -iE` regex fragments. They are matched against the
+item text **after** the leading `- [ ] ` has been stripped. Matches are
+case-insensitive.
+
+## Bucket 1 — auto-verify
+
+Items covered by a CI job or by `/wait-ci`'s own built-in checks. The
+skill flips `[ ]` → `[x]` and appends `— verified by /wait-ci @ <sha>`.
+
+```regex
+# "CI green" / "all checks pass" — trivially covered by the CI_VERDICT==green branch.
+^(all\s+(required\s+)?(ci\s+)?checks?\s+(are\s+)?green|ci\s+(is\s+)?green|all\s+green)
+# example: "- [ ] all required CI checks green"
+
+# "docs-link-check" / "lychee" — covered by the dedicated docs-link-check CI job.
+docs[- ]link[- ]?check|lychee\s+(passes|green|clean)
+# example: "- [ ] docs-link-check (lychee) passes."
+
+# "privacy check" / "just check-private" — covered by the privacy tree check CI job.
+privacy\s+(tree\s+)?check|just\s+check-private
+# example: "- [ ] just check-private still passes (no private/ paths in diff)."
+
+# "tests pass" — covered by the "just ci" matrix job running nextest.
+^(all\s+)?tests?\s+(pass|green)
+# example: "- [ ] tests pass"
+
+# "clippy clean" — covered by "just ci" running clippy -D warnings.
+clippy\s+(is\s+)?(clean|green|passes?)|no\s+clippy\s+warnings
+# example: "- [ ] clippy clean"
+
+# "conventional commit" — covered by the conventional-commits CI job.
+conventional[- ]commit
+# example: "- [ ] conventional commits workflow passes"
+
+# "gate 6a" / "gate 6b" / "PII scan self-check" — author ran the gate inline in the session
+# and noted "clean" / "confirmed" / "no leak".
+gate\s*6[ab]?\b.*(self[- ]check|clean|confirmed|no leak|no email literal)
+# example: "- [ ] Gate 6a (PII email scan) self-check on this diff — clean, confirmed."
+
+# "no X remains" / "grep confirms" — author's static grep assertion, reproducible in CI.
+grep\s+confirms|no\s+.{0,30}\s+remains|returns\s+only\s+prose\s+mentions
+# example: "- [ ] No abbreviation (AC, FM, …) remains in the section — grep confirms."
+```
+
+## Bucket 2 — auto-skip (manual-by-design)
+
+Items whose verdict requires a human eyeball or a manual environment.
+`[ ]` stays unchecked; the item is listed in the summary as
+"needs human verification".
+
+```regex
+# Visual smoke / render on GitHub / Mermaid render.
+render(s)?\s+(correctly|on\s+github|natively)|mermaid\s+render|manual\s+smoke
+# example: "- [ ] Mermaid renders on github.com (manual smoke after merge)."
+
+# "verify X on the deployed site" / "open in browser" / "load the page".
+(open|load|verify|check).{0,40}\b(in|on)\s+(the\s+)?(browser|github|deployed|prod)
+# example: "- [ ] open in browser and verify the hero image loads"
+
+# "dogfood" / "fresh clone" / "test on clean checkout".
+dogfood|fresh\s+clone|clean\s+checkout|from\s+scratch\s+(setup|install)
+# example: "- [ ] dogfood /wait-ci on the PR itself to validate the happy path."
+
+# "smoke test" / "smoke-test" not already covered by CI.
+^smoke[- ]test|\bsmoke\s+(a|the)\b
+# example: "- [ ] smoke-test the install flow on a fresh clone"
+
+# "manual verification" / "human to verify".
+(manual|human)\s+(verification|verify|check|inspection)|visually\s+(confirm|check)
+# example: "- [ ] visually confirm spacing on narrow viewports"
+```
+
+## Bucket 3 — auto-defer (follow-up work)
+
+Items that describe work the PR is explicitly NOT doing — the checklist
+is tracking them as follow-up. `[ ]` stays unchecked; the summary marks
+them with a `🔁` and suggests a `/file-issue` invocation.
+
+```regex
+# "track in a follow-up issue" / "file a follow-up".
+(track(ed)?\s+in|file(d)?\s+a?\s*)?follow[- ]?up\s+(issue|ticket|pr)
+# example: "- [ ] file a follow-up issue for the anticipation layer"
+
+# "future work" / "later PR" / "future PR".
+future\s+(work|pr|iteration)|later\s+pr|out\s+of\s+scope.{0,30}follow
+# example: "- [ ] future PR: add predicates for plan-feature's AC fields"
+
+# "backlogged" / "add to backlog".
+backlogged?|add\s+to\s+(the\s+)?backlog
+# example: "- [ ] backlogged under #52"
+```
+
+## Bucket 4 — fallthrough
+
+Anything that matches no pattern. Treated as `auto-skip` (conservative
+default): `[ ]` stays unchecked, item listed as "needs human verification".
+
+Reason for the conservative default: an agent that auto-verifies a
+predicate it doesn't understand ships false confidence. Better to surface
+unfamiliar items than to pretend they're resolved.
+
+## Extension rules
+
+When a predicate needs to be added or changed:
+
+- open a PR that edits this file and *also* touches the SKILL.md
+  classifier docs if the bucket semantics are changing;
+- every new regex MUST ship with a real PR-line example in a comment on
+  the line above;
+- keep regexes `grep -iE`-compatible; avoid features that require `rg`
+  or PCRE (the skill runs pure `grep`/`awk` for portability);
+- prefer narrow patterns over broad ones — false positives in
+  `auto-verify` silently check a box the author meant to track; false
+  negatives in `auto-skip` just move the item to the manual-pending
+  list, which is safe.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,7 @@ Invocation syntax differs by agent. Claude Code exposes these as slash commands 
 | `run-stress <scenario>` | After any storage / MVCC / cluster change. Mandatory evidence for those PRs |
 | `run-bench <mode> <baseline>` | Before claiming any perf win. Mandatory for `type:perf` PRs |
 | `file-issue <title>` | End of `plan-feature`; any tracked task > 1 h of effort |
+| `wait-ci [pr]` | After every `gh pr create` and after every re-push on a red PR. Polls CI, walks the test-plan checklist, posts the verdict. Mandatory gate before flipping an issue to `status:needs-review` |
 
 Read [`.claude/skills/README.md`](./.claude/skills/README.md) for the full catalog, conventions, and the Tier 3 backlog (proptest / loom / fuzz scaffolds, regression diff tool, subagent delegations).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Codex syntax: the same skills are invoked with `$onboard`, `$next`, `$plan-featu
 | 5b | `/run-bench` *(conditional)* | Mandatory evidence for any PR labelled `type:perf` (AGENTS.md §§1.2, 8) |
 | 6 | `/pre-commit-check` | Local mirror of the CI gate: fmt, clippy, tests, doc-tests, link-check, private path check, secrets scan, conventional commit subject |
 | 7 | `git commit && git push && gh pr create` | Conventional commit subject · PR template auto-fills summary + test plan · branch `agent/<n>-<slug>` carries the issue number |
-| 8 | `/wait-ci` | Poll CI, walk the PR test-plan checklist, report the verdict on the PR · returns `success` / `pending-human` / `fail` (see [#52](https://github.com/mroche14/physa-db/issues/52) for current status of this skill) |
+| 8 | `/wait-ci` | Poll CI, walk the PR test-plan checklist against the predicate library, post the single verdict comment · returns `success` / `pending-human` / `fail` / `timeout` |
 
 "Done" is **PR green + checklist resolved**, not "PR open". See AGENTS.md §6.1.
 
@@ -71,7 +71,7 @@ The skills catalog organised by *when to use*, not by tier. Every skill lives un
 | Before commit | [`/pre-commit-check`](.claude/skills/pre-commit-check/SKILL.md) | §§1, 4, 5, 7, 8 | every commit |
 | Storage / MVCC / cluster change | [`/run-stress`](.claude/skills/run-stress/SKILL.md) | §5 | every such PR |
 | Perf claim | [`/run-bench`](.claude/skills/run-bench/SKILL.md) | §§1.2, 8 | every `type:perf` PR |
-| After push | `/wait-ci` *(see [#52](https://github.com/mroche14/physa-db/issues/52))* | §6.1 | every `gh pr create` |
+| After push | `/wait-ci` | §6.1 | every `gh pr create` |
 | Reviewing a PR | [`/review-pr`](.claude/skills/review-pr/SKILL.md) | §§1, 5, 7, 8, 11, 12, 15 | every PR review |
 | Track follow-up | [`/file-issue`](.claude/skills/file-issue/SKILL.md) | §6 | any task > 1 h of effort |
 | Can't finish | [`/abandon`](.claude/skills/abandon/SKILL.md) | §§3, 6.1 | every unfinished task |

--- a/README.md
+++ b/README.md
@@ -158,28 +158,28 @@ flowchart TD
 
     m2 --> next
 
-    first([first time on this clone]) --> onboard[/onboard/]
-    onboard --> next[/next/]
+    first([first time on this clone]) --> onboard[/"/onboard"/]
+    onboard --> next[/"/next"/]
     repeat([any subsequent session]) --> next
 
     next -->|acceptance criteria<br/>present in issue| code[write code<br/>run-stress / run-bench as needed]
-    next -->|acceptance criteria<br/>missing| plan[/plan-feature/]
+    next -->|acceptance criteria<br/>missing| plan[/"/plan-feature"/]
     plan --> code
 
-    code --> precheck[/pre-commit-check/]
+    code --> precheck[/"/pre-commit-check"/]
     precheck -->|fail| code
     precheck -->|pass| push[commit + push<br/>gh pr create]
-    push --> waitci[/wait-ci/]
+    push --> waitci[/"/wait-ci"/]
 
     waitci -->|✅ all green| review([PR → status:needs-review])
     waitci -->|⏳ timeout| resume([surface + resume later])
     waitci -->|❌ CI fails| retries{≤ 3 fix<br/>iterations?}
 
     retries -->|yes| code
-    retries -->|no| nh[/abandon → agent:needs-human/]
+    retries -->|no| nh[/"/abandon → agent:needs-human"/]
 
-    code -. stuck / blocker .-> blocked[/abandon → status:blocked/]
-    code -. new bug surfaced .-> fileissue[/file-issue/]
+    code -. stuck / blocker .-> blocked[/"/abandon → status:blocked"/]
+    code -. new bug surfaced .-> fileissue[/"/file-issue"/]
     fileissue -.-> m2
 
     classDef skill fill:#e8f0ff,stroke:#4a6fa5,color:#1a2a3a


### PR DESCRIPTION
## What

Closes #52. The \`/wait-ci\` skill is now real, not a doc placeholder.
Two files under \`.claude/skills/wait-ci/\`:

- \`SKILL.md\` — the playbook: resolve PR number, poll CI (20 min cap),
  walk the test-plan checklist, patch the PR body with auto-verified
  \`[x]\` marks, post a single structured summary comment, return a
  4-way verdict (\`success\` / \`pending-human\` / \`fail\` /
  \`timeout\`).
- \`predicates.md\` — the regex library: three buckets (auto-verify /
  auto-skip / auto-defer) scanned in order, every pattern shipped
  with a real PR-line example on the comment line above it. New
  patterns without examples are rejected in review.

\`/next\` Step 9 is rewritten to delegate to \`/wait-ci\` and dispatch
on the exit code (9a=success, 9b=pending-human, 9c=fail-loop capped at
3, 9d=still-fail handoff, 9e=timeout). The previous inline
\`gh pr checks --watch\` block is deleted.

AGENTS.md §16, CONTRIBUTING.md, and the skills catalog README are
updated to refer to the now-existing skill (no more \"see #52\"
placeholders).

## Why

Every PR opened in the last ~8 hours of this session left its
\`## Test plan\` checklist unchecked forever, because no skill was
walking it. The invariant codified in #52 — *"PR open ≠ done; PR
green + checklist resolved = done"* — was not mechanically enforced.

With this PR, any agent that invokes \`/wait-ci <N>\` after
\`gh pr create\`:

- blocks until CI settles,
- auto-verifies checklist items covered by CI (tests, clippy,
  lychee, privacy check, conventional commits),
- surfaces manual items (visual smoke, dogfood, render on GitHub)
  as \`⚠️ needs human verification\`,
- flags follow-up items (\"future PR\", \"backlog\") as
  \`🔁 deferred to follow-up\`,
- posts a single verdict comment and returns an exit code that
  \`/next\` dispatches on.

## Test plan

- [ ] Dogfood: run \`/wait-ci\` on this very PR once CI finishes.
      The skill should auto-verify the docs-link-check / CI-green
      boxes and surface the dogfood item as manual-pending.
- [x] all required CI checks green — verified by /wait-ci @ 368ba44
- [x] docs-link-check (lychee) passes — verified by /wait-ci @ 368ba44
- [x] Gate 6a (PII email scan) self-check on this diff — clean, — verified by /wait-ci @ 368ba44
      confirmed
- [x] Gate 6b (user.email in bash block) self-check — clean, — verified by /wait-ci @ 368ba44
      confirmed
- [ ] Manual smoke after merge: next PR opened by any agent runs
      \`/wait-ci\` as the Step 9 gate and writes a summary comment

## Out of scope

- **Anticipation layer** (the other half of #52's AC): pin cargo-lychee
  in \`.mise.toml\`, add \`just check-links\` and wire it into
  \`just ci\`, update \`/pre-commit-check\` to note link-check
  coverage. The local mirror of the CI docs-link-check job is useful
  but not on the critical path for today's "test-plan boxes forever
  empty" complaint. File a follow-up issue and pick it up in a
  separate PR.

## Implementation notes

- \`/wait-ci\` is idempotent: re-running it deletes any previous
  \`<!-- wait-ci:* -->\` marker comment before posting the new one.
  No comment accumulation.
- The skill uses \`timeout 1200 gh pr checks --watch --fail-fast\`
  to bound the poll loop; \`timeout\` returning 124 is the timeout
  sentinel.
- Body patching uses \`gh pr edit --body-file -\` (PR-body-only
  metadata, no commit touched, as noted in the #52 hints).
- \`classify\` (the function that maps an item's text to a bucket)
  reads \`predicates.md\` at runtime. Agents invoking the skill can
  implement it either inline or by sourcing the regex blocks — the
  SKILL.md leaves the exact shape open, documenting the contract
  rather than the code.