### PR TITLE
fix(infra): eliminate stash leak root cause in release-plz dry-run

### DIFF
--- a/.github/scripts/release-plz-dry-run.sh
+++ b/.github/scripts/release-plz-dry-run.sh
@@ -14,13 +14,25 @@ trap cleanup EXIT
 
 git -C "$ROOT" worktree add -b "$TMP_BRANCH" "$TMP_WORKTREE" HEAD
 git -C "$TMP_WORKTREE" branch --set-upstream-to=origin/main "$TMP_BRANCH"
+# Bake any dirty diff into a disposable commit in the worktree, rather than
+# leaving it unstaged. release-plz would otherwise need --allow-dirty and
+# stash internally, and refs/stash is a global ref shared across worktrees —
+# so its stash would survive the worktree removal and accumulate in the
+# caller's repo. With a clean worktree, release-plz never stashes.
+# The "chore(release):" prefix is `skip = true` in release-plz.toml so the
+# commit does not pollute the previewed CHANGELOG.
 if ! git -C "$ROOT" diff --quiet HEAD -- . ":(exclude)private/**"; then
   git -C "$ROOT" diff --binary HEAD -- . ":(exclude)private/**" |
     git -C "$TMP_WORKTREE" apply --allow-empty
+  git -C "$TMP_WORKTREE" add --all
+  git -C "$TMP_WORKTREE" \
+    -c user.name=physa-dry-run \
+    -c user.email=physa-dry-run@users.noreply.github.com \
+    commit --allow-empty -m "chore(release): dry-run preview (disposable)"
 fi
 
 cd "$TMP_WORKTREE"
-"$RELEASE_PLZ" update --manifest-path Cargo.toml --allow-dirty
+"$RELEASE_PLZ" update --manifest-path Cargo.toml
 
 echo
 echo "Disposable release-plz package/version/changelog changes in the temporary worktree:"


### PR DESCRIPTION
## Summary

Closes #44.

`release-plz update` stashed unconditionally when its worktree was dirty, and `refs/stash` is a **global ref shared across worktrees** — so the stash survived the temporary worktree's removal and accumulated in the caller's main repo (observed: up to 4 stashes titled `On tmp/release-plz-dry-run-<ts>-<pid>: uncommitted changes stashed by release-plz`).

**Root cause attacked, not symptom.** Previous attempts patched the consequence (cleanup post-run); this one removes the trigger. The script now:

1. bakes the caller's dirty diff into a disposable `chore(release): dry-run preview` commit inside the temporary worktree — `chore(release):` is `skip = true` in `release-plz.toml` `commit_parsers`, so the CHANGELOG preview is unaffected;
2. drops `--allow-dirty` from the `release-plz update` invocation;
3. with a clean worktree, `release-plz` never reaches the code path that stashes — the leak is impossible by construction, even on SIGTERM/SIGKILL.

No functional change to what the dry-run prints. Trap cleanup still removes the temporary worktree + branch on exit.

Out of scope (noted in #44): `.github/workflows/release-plz.yml` doesn't invoke this script (it calls `release-plz/action` directly), so CI runners aren't affected.

## Test plan

- [x] `git stash list` unchanged after a clean-tree `just release-plz-dry-run` (happy path, zero dirty diff applied).
- [x] `git stash list` unchanged after a dirty-tree `just release-plz-dry-run` (the original leak scenario).
- [x] `git stash list` unchanged after `kill -TERM` mid-run on a dirty tree (trap + no stash ever created).
- [x] `cargo fmt --all --check` passes.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes.
- [x] `cargo nextest run --workspace --all-features` passes (11 tests).
- [x] No residual `tmp/release-plz-dry-run-*` branches or worktrees after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)