### PR TITLE
fix(infra): stop release-plz from rendering dead v0.0.0 release links

### DIFF
--- a/crates/physa-cli/CHANGELOG.md
+++ b/crates/physa-cli/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.0](https://github.com/mroche14/physa-db/releases/tag/physa-cli-v0.0.0) - 2026-04-20
+## [0.0.0] - 2026-04-20
 
 ### CI
 

--- a/crates/physa-client/CHANGELOG.md
+++ b/crates/physa-client/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.0](https://github.com/mroche14/physa-db/releases/tag/physa-client-v0.0.0) - 2026-04-20
+## [0.0.0] - 2026-04-20
 
 ### Chores
 

--- a/crates/physa-cluster/CHANGELOG.md
+++ b/crates/physa-cluster/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.0](https://github.com/mroche14/physa-db/releases/tag/physa-cluster-v0.0.0) - 2026-04-20
+## [0.0.0] - 2026-04-20
 
 ### Chores
 

--- a/crates/physa-core/CHANGELOG.md
+++ b/crates/physa-core/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.0](https://github.com/mroche14/physa-db/releases/tag/physa-core-v0.0.0) - 2026-04-20
+## [0.0.0] - 2026-04-20
 
 ### CI
 

--- a/crates/physa-query/CHANGELOG.md
+++ b/crates/physa-query/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.0](https://github.com/mroche14/physa-db/releases/tag/physa-query-v0.0.0) - 2026-04-20
+## [0.0.0] - 2026-04-20
 
 ### Chores
 

--- a/crates/physa-server/CHANGELOG.md
+++ b/crates/physa-server/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.0](https://github.com/mroche14/physa-db/releases/tag/physa-server-v0.0.0) - 2026-04-20
+## [0.0.0] - 2026-04-20
 
 ### Chores
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,13 +2,7 @@
 # CLI flags in .github/workflows/ci.yml combine with this config.
 
 # URLs to skip entirely. Keep this list small and always include a reason.
-exclude = [
-    # release-plz generates CHANGELOG entries with `release_link` pointing to
-    # tags like `physa-<crate>-v0.0.0` before those tags actually exist on
-    # GitHub. Remove this entry once real v0.0.0 (or later) releases are cut.
-    # Tracked in: fix(infra): release-plz generates CHANGELOG links to unreleased tags
-    "^https://github\\.com/mroche14/physa-db/releases/tag/physa-[a-z]+-v0\\.0\\.0$",
-]
+exclude = []
 
 # Don't follow localhost / loopback — duplicates the CLI flag, belt-and-braces.
 exclude_loopback = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 """
 body = """
 
-## [{{ version }}]{% if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}


### PR DESCRIPTION
## Summary

- Drop `release_link` from the release-plz changelog body template so per-crate `CHANGELOG.md` headers render as `## [{{ version }}] - {{ date }}` with no hyperlink. The existing `{% if release_link %}` guard was inert because release-plz populates `release_link` prospectively whenever `git_release_enable = true`, regardless of whether the release actually exists.
- Rewrite the six baked-in `## [0.0.0](https://.../physa-<crate>-v0.0.0) - 2026-04-20` headers in the per-crate `CHANGELOG.md` files to strip the dead URL. Those links were committed by PR #28 and have been 404 since the repo went public on 2026-04-23.
- Remove the temporary `^https://github\.com/mroche14/physa-db/releases/tag/physa-[a-z]+-v0\.0\.0$` exclusion from `lychee.toml` (added by PR #50 to unblock CI) now that the source of the bad links is gone.

## Acceptance criteria (from #51)

- [x] CHANGELOG.md files in every crate contain no link to a non-existent release tag.
- [x] `lychee.toml` exclusion removed.
- [x] CI `docs link check` green with the exclusion removed. — verified by /wait-ci @ 0cc3a3a

## Out of scope

- Cutting a real v0.0.0 (or v0.1.0) release. Fix works regardless of whether releases ever get cut.
- Re-introducing hyperlinked version headers for future real releases — that's a separate decision (future ADR candidate: "how do we want CHANGELOG headers to point at releases?").

## Test plan

- [x] `docs link check` CI job passes on this branch (lychee runs with no exclusion — the previously-broken `physa-<crate>-v0.0.0` links are gone). — verified by /wait-ci @ 0cc3a3a
- [x] `grep -rE 'releases/tag/physa-[a-z]+-v0\.0\.0' .` returns zero hits across the working tree. — verified by /wait-ci @ 0cc3a3a
- [x] All other CI gates (`workspace-core`, `conventional-commits`, `private-paths`) remain green. — verified by /wait-ci @ 0cc3a3a

## Links

- Closes #51
- Unblocking PR that added the now-removed exclusion: #50
- Genesis PR that baked in the dead links: #28

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

