### PR TITLE
feat(infra): /wait-ci predicate matches "grep … returns N hits" assertions

### DIFF
--- a/.claude/skills/wait-ci/predicates.md
+++ b/.claude/skills/wait-ci/predicates.md
@@ -51,6 +51,12 @@ gate\s*6[ab]?\b.*(self[- ]check|clean|confirmed|no leak|no email literal)
 # "no X remains" / "grep confirms" — author's static grep assertion, reproducible in CI.
 grep\s+confirms|no\s+.{0,30}\s+remains|returns\s+only\s+prose\s+mentions
 # example: "- [ ] No abbreviation (AC, FM, …) remains in the section — grep confirms."
+
+# "grep/rg <cmd> returns N hits/matches/results/lines" — same intent as the above,
+# different phrasing. Narrow: requires the line to name grep or rg, and to end the
+# assertion with one of the counted-noun keywords. Zero, no, and 0 are all accepted.
+(grep|rg)\s.{0,120}returns?\s+(zero|no|0)\s+(hits?|matches?|results?|lines?)
+# example: "- [ ] grep -rE 'foo' . returns zero hits across the working tree."
 ```
 
 ## Bucket 2 — auto-skip (manual-by-design)


### PR DESCRIPTION
## Summary

- Extend `.claude/skills/wait-ci/predicates.md` bucket 1 to auto-verify the "`grep|rg … returns (zero|no|0) (hits|matches|results|lines)`" family of test-plan assertions. Previously these fell through to the conservative manual-pending bucket even though the assertion is reproducible at zero cost.

## Acceptance criteria (from #74)

- [x] Extend the bucket 1 regex to additionally match `grep/rg … returns zero/no/0 hits/matches/results/lines` with a narrow pattern.
- [x] Ship a commented example alongside the new regex per predicates.md's extension rule.
- [x] Dry-run the amended library against PR #73's unmatched line — rg -qE 'returns zero hits' now auto-verifies instead of falling through.

## Test plan

- [x] Dry-run of the new pattern against 11 cases (5 positives / 6 negatives) — grep confirms exactly 5 matches and 0 false positives.
- [ ] On PR #73 merge or rebase, a re-run of `/wait-ci` shows the previously-⚠️ grep item flipping to ✅ — manual smoke after this lands.
- [x] Conventional-commits CI green. — verified by /wait-ci @ f54e598
- [x] Privacy tree check (§7) CI green. — verified by /wait-ci @ f54e598
- [x] docs-link-check CI green (lychee clean). — verified by /wait-ci @ f54e598

## Out of scope

- Broader bucket-1 overhaul (e.g. `cargo check` assertions, build-artefact presence). One narrow addition; more patterns can follow once real usage demands them.
- Rewriting PR #73's body — that PR will be merged or rebased independently.

## Links

- Closes #74
- Source of the surfaced gap: PR #73 (fix(infra): dead v0.0.0 release links)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

