### PR TITLE
feat(infra): require milestone on every issue (skill + CI gate)

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -41,7 +41,7 @@ Bugs, features, perf investigations, stress-test failures, research
 tasks, docs gaps — all are issues. Refactors that nobody asked for are
 not.
 
-## Step 2 — Choose labels
+## Step 2 — Choose labels and milestone
 
 Combine one label from each applicable prefix (`AGENTS.md` §6):
 
@@ -55,6 +55,16 @@ Combine one label from each applicable prefix (`AGENTS.md` §6):
 - **`agent:`** — `agent:good-first-task` for newly-onboarded agents,
   `agent:needs-human` if human judgement is required, `agent:long-running`
   if the task is > 1 day.
+
+**Milestone is required.** Every issue must be filed against a milestone
+(`AGENTS.md` §6). The `/next` skill filters by milestone; an issue with
+none falls outside discovery and gets stranded. List milestones with
+`gh api repos/:owner/:repo/milestones --jq '.[].title'` and pick the one
+that captures *when* this work belongs. If the answer is "I don't know
+yet", that decision must be made before filing — do **not** default to
+the current milestone "to unblock". The CI gate
+(`.github/workflows/issue-milestone-gate.yml`) will refuse a milestone-less
+issue and force `agent:needs-human` until a human decides.
 
 ## Step 3 — Fill the template
 
@@ -127,6 +137,7 @@ line and move on.>
 
 - [ ] Title is imperative, ≤ 72 chars.
 - [ ] Labels: area, type, status, priority, agent.
+- [ ] Milestone assigned (no exceptions — see AGENTS.md §6).
 - [ ] FM row cited (or "not applicable — explain").
 - [ ] Optimization research brief present and exhaustive (or explicit
       "no optimisation surface" for trivial plumbing).
@@ -136,18 +147,33 @@ line and move on.>
 
 ## Step 4 — File it
 
+The skill **refuses** to call `gh issue create` without `--milestone`.
+The flag is mandatory — not a default, not a fallback. If you cannot
+name the milestone, go back to Step 2 and decide; do not paper over
+the gap with a placeholder.
+
 ```bash
+# Sanity-check: milestone exists and is open.
+MILESTONE="<milestone title>"   # e.g. "M0 — Foundation"
+gh api repos/:owner/:repo/milestones --jq '.[] | select(.state == "open") | .title' \
+  | grep -Fxq "$MILESTONE" \
+  || { echo "Refusing to file: milestone '$MILESTONE' not found among open milestones." >&2; exit 1; }
+
 gh issue create \
   --title "<imperative title>" \
   --label "area:<x>,type:<y>,status:ready,priority:<p>,agent:<q>" \
+  --milestone "$MILESTONE" \
   --body-file /tmp/issue-body.md
 ```
 
-Or via the browser with the template pre-filled if you prefer the UI.
+If you use the browser instead of the CLI, the milestone field on the
+right-hand sidebar must be set **before** clicking "Submit new issue".
+The CI gate (see `.github/workflows/issue-milestone-gate.yml`) will
+otherwise label the issue `agent:needs-human` and force a human to
+decide which milestone the work belongs to.
 
 ## Step 5 — Post-create
 
-- Add the issue to the relevant GitHub Project (milestone → M1/M2/M3/...).
 - If this is the feature branch kickoff, open a PR stub with
   `Closes #<N>`.
 - If this blocks other issues, add `Depends on #X` lines and update the
@@ -164,6 +190,9 @@ Or via the browser with the template pre-filled if you prefer the UI.
   `plan-feature` first to add it.
 - Do not use `status:in-progress` at creation time. Start at
   `status:ready`; the agent picking up the work flips it.
+- Do not file an issue without a milestone. The CI gate will catch it
+  and label it `agent:needs-human` — that's a triage burden you've
+  punted to a maintainer. Pick the milestone in Step 2.
 - Do not include personal information in the issue body (email
   addresses, legal names, phone numbers, home directory paths,
   hostnames). The issue is public. Refer to yourself or other

--- a/.github/workflows/issue-milestone-gate.yml
+++ b/.github/workflows/issue-milestone-gate.yml
@@ -1,0 +1,73 @@
+name: Issue milestone gate
+
+# Enforces "every issue carries a milestone" (AGENTS.md §6, issue #76).
+#
+# When an issue is opened or edited without a milestone, this workflow:
+#   - adds the `agent:needs-human` label (the human decides which
+#     milestone the work belongs to — we do not auto-default);
+#   - posts a one-time policy comment explaining why and how to fix.
+#
+# When a milestone is present, this workflow is a no-op. It does NOT
+# proactively remove `agent:needs-human` — the human who attached the
+# milestone owns clearing the label after triage.
+#
+# Idempotency: a hidden marker comment (`<!-- milestone-gate-marker -->`)
+# guards against duplicate comments across re-fires (e.g. body edits on
+# a still-milestone-less issue). The label add is naturally idempotent.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # One run per issue; never cancel — a body edit must not pre-empt the
+  # opened-event run for the same issue.
+  group: issue-milestone-gate-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    if: github.event.issue.milestone == null
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE: ${{ github.event.issue.number }}
+      REPO: ${{ github.repository }}
+      AGENTS_URL: ${{ github.server_url }}/${{ github.repository }}/blob/main/AGENTS.md#6-project-tracking-the-system-of-record
+    steps:
+      - name: Add agent:needs-human label
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE" \
+            --repo "$REPO" \
+            --add-label agent:needs-human
+
+      - name: Post policy comment (idempotent)
+        run: |
+          set -euo pipefail
+          MARKER="<!-- milestone-gate-marker -->"
+
+          ALREADY="$(gh issue view "$ISSUE" \
+            --repo "$REPO" \
+            --json comments \
+            --jq "[.comments[] | select(.body | contains(\"$MARKER\"))] | length")"
+
+          if [[ "$ALREADY" -gt 0 ]]; then
+            echo "Marker comment already posted on #$ISSUE; skipping."
+            exit 0
+          fi
+
+          {
+            printf '**This issue is missing a milestone.**\n\n'
+            printf 'physa-db requires every issue to carry a milestone — no exceptions. See [`AGENTS.md` §6](%s). Without a milestone the issue falls outside the `/next` skill'"'"'s discovery filter and gets stranded.\n\n' "$AGENTS_URL"
+            printf 'The `agent:needs-human` label has been applied. To clear it: pick the milestone this work belongs to (sidebar → Milestone, or `gh issue edit %s --milestone <name>`), then remove the label. Do not default to the current milestone to unblock — the choice is the point.\n\n' "$ISSUE"
+            printf '%s\n' "$MARKER"
+          } > /tmp/milestone-gate-body.md
+
+          gh issue comment "$ISSUE" \
+            --repo "$REPO" \
+            --body-file /tmp/milestone-gate-body.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Every **core** CI gate is a local `just` command — **if it passes locally, it 
 **Single source of truth: GitHub Issues + GitHub Projects v2.** See ADR-0001.
 
 - Every task, bug, feature, research item is a GitHub Issue.
+- **Every issue carries a milestone — no exceptions.** The `/next` skill filters by milestone; an issue without one falls outside discovery and gets stranded. The `issue-milestone-gate.yml` workflow enforces this on every `issues.opened` / `issues.edited` event: a milestone-less issue is auto-labelled `agent:needs-human` and a one-time policy comment is posted (idempotent — guarded by a hidden marker). The `/file-issue` skill refuses to call `gh issue create` without `--milestone`. Do not default to the current milestone "to unblock" — the choice of which milestone the work belongs to *is the work* of triage, and the gate exists so an external contributor running `/next` never has to debug a triage gap.
 - The GitHub Pages dashboard (`dashboard/`) reads a pre-generated `dashboard/data/state.json`, rebuilt by `snapshot-dashboard.yml` when that workflow is enabled.
 - **Do not** create parallel tracking systems (TODO files, taskwarrior, etc.). If you need transient state inside a task, put it in a PR description or issue comment.
 


### PR DESCRIPTION
## What

Closes #76. Two complementary controls so a milestone-less GitHub issue stops being possible: (a) `/file-issue` refuses to call `gh issue create` without `--milestone`; (b) a new `issue-milestone-gate.yml` workflow auto-labels any milestone-less issue `agent:needs-human` with a one-time policy comment.

## Why

`/next` filters by milestone. A `status:ready` issue with no milestone falls outside discovery and gets stranded — exactly the friction M0 is meant to eliminate. The widened-fallback in `/next` (PR #78) was a workaround; the root cause is that issues are being filed without a milestone in the first place. Closing the gap at the filing surface AND with a CI safety net is the durable fix.

## How

- **`.claude/skills/file-issue/SKILL.md`** — Step 2 renamed to "Choose labels and milestone" with an explicit rule to pick the milestone before filing (no defaulting "to unblock"). Step 4 pre-flights that the milestone exists among open milestones, then `gh issue create` includes `--milestone "$MILESTONE"`. Step 5 drops the post-create milestone-add line. Author checklist gains a milestone item; "What NOT to do" calls out the failure mode.
- **`.github/workflows/issue-milestone-gate.yml`** — fires on `issues.opened` and `issues.edited`. Job-level `if: github.event.issue.milestone == null` makes the milestoned path a no-op (no API calls, free CI minutes). When milestone is null: add `agent:needs-human` (idempotent), then check existing comments for a `<!-- milestone-gate-marker -->` and only post the policy comment when absent. Concurrency group is per-issue with `cancel-in-progress: false` so a body edit doesn't pre-empt the opened-event run. Comment links to `AGENTS.md §6` via `${{ github.server_url }}/${{ github.repository }}/blob/main/...` (works regardless of fork).
- **`AGENTS.md` §6** — codifies the "every issue carries a milestone — no exceptions" policy alongside the rest of project tracking, naming the workflow that enforces it and the skill that prevents the violation upfront.

## Checklist

- [x] Pre-commit gates locally (markdown + YAML only — Rust gates N/A; CI runs them)
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Bash blocks pass `bash -n`
- [x] No PII, no secrets, no `private/` references
- [x] AGENTS.md §6 mentions the workflow + skill so future agents know where the policy lives

## Test plan

- [x] CI green on this PR (markdown lint, YAML lint, conventional-commits, etc.).
- [ ] **Manual integration test (post-merge)** per the issue's acceptance criteria:
  1. File a test issue without a milestone → workflow fires, `agent:needs-human` is added, policy comment appears with the marker.
  2. Edit the issue body (still no milestone) → label is idempotent, no duplicate comment (marker check skips).
  3. Assign a milestone → workflow fires but the job is skipped via the `if:` condition (no comment, no label change).
  4. Remove the milestone again → job runs but the marker check skips the comment; label is re-added if it was cleared (idempotent).

The manual integration test runs against live GitHub Actions and so cannot be automated within this PR's CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Nc9eFoxp5xN5YqgYQArA4)_